### PR TITLE
Import 1Password downstream changes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,7 +46,7 @@ once_cell = { version = "1.9", optional = true } # Only used during doc generati
 [target.'cfg(target_os = "linux")'.dependencies]
 rustls-native-certs = "0.6"
 once_cell = "1.9"
-webpki-roots = "0.22" # Fallback when `openssl-probe` can't find anything.
+webpki-roots = "0.22" # Augmentation to `openssl-probe` due to inconsistencies on Linux distros.
 
 [target.'cfg(target_os = "android")'.dependencies]
 jni = { version = "0.19", default-features = false }


### PR DESCRIPTION
This PR imports all the changes that we (1Password) had applied to our local version of this crate in order to fix issues we encountered in production.

These include:
- Fixing a crash while verifying a certificate on macOS. We're not sure why this was actually happening and we're unable to narrow the cause down, but we suspect someone's system clock or network setup was introducing a bad timestamp somewhere. A [short discussion](https://discord.com/channels/976380008299917365/1015156984007381033/1074853630613659689) on the rustls Discord server agreed that "...probably makes sense to error out" regardless.
- Unconditionally including the trust anchors from `webpki-roots` on Linux for certificate verification. These are now always mixed into the certificates loaded from the system (if any). In production we've found `openssl-probe` to be fairly unreliable on older installations of even standard distros, leading to no roots for our server's (one of Amazon's Root CAs) certificate being found.

I believe that only the second change would be controversial, but AFAIK we still need to rework how `webpki-roots` is used at all in this crate so I don't feel its that big of a deal at the moment and would help accelerate those.