### PR TITLE
Improve Android dependency versioning 

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,18 @@ ext.findRustlsPlatformVerifierProject = {
 This script can be tweaked as best suits your project, but the `cargo metadata` invocation must be included so that the Android
 implementation source can be located on disk.
 
+If your project often updates its Android Gradle Plugin versions, you should additionally consider setting your app's project
+up to override `rustls-platform-verifier`'s dependency versions. This allows your app to control what versions are used and avoid
+conflicts. To do so, advertise a `versions.path` system property from your `settings.gradle`:
+
+```groovy
+ext.setVersionsPath = {
+    System.setProperty("versions.path", file("your/versions/path.toml").absolutePath)
+}
+
+setVersionsPath()
+```
+
 Finally, sync your gradle project changes. It should pick up on the `rustls-platform-verifier` Gradle project. It should finish
 successfully, resulting in a `rustls` group appearing in Android Studio's project view.
 After this, everything should be ready to use. Future updates of `rustls-platform-verifier` won't need any maintenance beyond the

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,10 +1,8 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 buildscript {
-    ext.kotlinVersion = '1.6.10'
-    ext.agpVersion = '7.3.0'
     dependencies {
-        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinVersion"
-        classpath "com.android.tools.build:gradle:$agpVersion"
+        classpath libs.kotlin.gradle.plugin
+        classpath libs.android.gradle.plugin
     }
 
     repositories {

--- a/android/gradle/libraries.versions.toml
+++ b/android/gradle/libraries.versions.toml
@@ -1,0 +1,6 @@
+[versions]
+kotlin = "1.6.10"
+
+[libraries]
+android-gradle-plugin = { group = "com.android.tools.build", name = "gradle", version = "7.3.0" }
+kotlin-gradle-plugin = { group = "org.jetbrains.kotlin", name = "kotlin-gradle-plugin", version.ref = "kotlin" }

--- a/android/rustls-platform-verifier/build.gradle
+++ b/android/rustls-platform-verifier/build.gradle
@@ -90,11 +90,10 @@ task ktlintFormat(type: JavaExec, group: "formatting") {
 }
 
 dependencies {
-    implementation 'androidx.core:core-ktx:1.8.0'
     testImplementation 'junit:junit:4.13.2'
     androidTestImplementation 'androidx.test.ext:junit:1.1.3'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.4.0'
-    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlinVersion"
+    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:${libs.versions.kotlin.get()}"
 
     ktlint 'com.pinterest:ktlint:0.46.1'
 }

--- a/android/settings.gradle
+++ b/android/settings.gradle
@@ -11,6 +11,22 @@ dependencyResolutionManagement {
         google()
         mavenCentral()
     }
+
+    // We use a version catalog for two reasons:
+    // 1. Ease of dependency management
+    // 2. Supporting having our versions overridden by a larger project including us
+    // as a composite build. This lets versions stay in sync when they would otherwise become
+    // incompatible. Examples of this include AGP, where an actual app might have a newer one
+    // then this library (which doesn't need to).
+    //
+    // This works by first trying to read global property that a parent module could advertise
+    // and then falling back to our local definitions. In combination, both project-local tasks
+    // still work as intended and use as a library in a full application.
+    versionCatalogs {
+        libs {
+            from(files(System.getProperty("versions.path", "gradle/libraries.versions.toml")))
+        }
+    }
 }
 rootProject.name = "rustls"
 include ':rustls-platform-verifier'


### PR DESCRIPTION
This PR allows any project using the Android component of `rustls-platform-verifier` to control the versions of Android Gradle Plugin and Kotlin used during compilation in a Gradle Composite build.

At work, we ran into an issue when trying to update AGP: The version declared here, 7.3.0, was completely incompatible during resolution with 7.4.0. So, after some work, we added a way for our main Gradle project to supply dependency versions to keep them in sync easier and not force a version of the plugin on anyone. Our Kotlin requirements are dead-simple, so this shouldn't cause any compatibility problems.