### PR TITLE
Android Gradle Plugin upgrade compat changes

### DIFF
--- a/android/rustls-platform-verifier/build.gradle
+++ b/android/rustls-platform-verifier/build.gradle
@@ -31,6 +31,8 @@ android {
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
 
+    namespace "org.rustls.platformverifier"
+
     buildTypes {
         release {
             minifyEnabled false
@@ -67,6 +69,9 @@ android {
             }
         }
     }
+    buildFeatures {
+        buildConfig true
+    }
 }
 
 configurations {
@@ -75,7 +80,7 @@ configurations {
 
 task ktlint(type: JavaExec, group: "verification") {
     description = "Check Kotlin code style."
-    main = "com.pinterest.ktlint.Main"
+    mainClass = "com.pinterest.ktlint.Main"
     classpath = configurations.ktlint
     args "src/**/*.kt"
 }
@@ -84,7 +89,7 @@ check.dependsOn ktlint
 
 task ktlintFormat(type: JavaExec, group: "formatting") {
     description = "Fix Kotlin code style deviations."
-    main = "com.pinterest.ktlint.Main"
+    mainClass = "com.pinterest.ktlint.Main"
     classpath = configurations.ktlint
     args "-F", "src/**/*.kt"
 }

--- a/android/rustls-platform-verifier/src/androidTest/java/org/rustls/platformverifier/CertificateVerifierTests.kt
+++ b/android/rustls-platform-verifier/src/androidTest/java/org/rustls/platformverifier/CertificateVerifierTests.kt
@@ -1,4 +1,4 @@
-package rustls.platformverifier.android
+package org.rustls.platformverifier
 
 import android.content.Context
 import androidx.test.ext.junit.runners.AndroidJUnit4

--- a/android/rustls-platform-verifier/src/main/AndroidManifest.xml
+++ b/android/rustls-platform-verifier/src/main/AndroidManifest.xml
@@ -1,3 +1,2 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="org.rustls.platformverifier"/>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"/>

--- a/android/rustls-platform-verifier/src/main/AndroidManifest.xml
+++ b/android/rustls-platform-verifier/src/main/AndroidManifest.xml
@@ -1,3 +1,3 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="rustls.platformverifier.android"/>
+    package="org.rustls.platformverifier"/>

--- a/android/rustls-platform-verifier/src/main/java/org/rustls/platformverifier/CertificateVerifier.kt
+++ b/android/rustls-platform-verifier/src/main/java/org/rustls/platformverifier/CertificateVerifier.kt
@@ -1,4 +1,4 @@
-package rustls.platformverifier.android
+package org.rustls.platformverifier
 
 import android.content.Context
 import android.net.http.X509TrustManagerExtensions

--- a/src/tests/ffi.rs
+++ b/src/tests/ffi.rs
@@ -36,8 +36,14 @@ mod android {
     ) -> JString<'a> {
         // These can't fail, and even if they did, Android will crash the process like we want.
         ANDROID_INIT.call_once(|| {
+            let log_filter = android_logger::FilterBuilder::new()
+                .filter_module("jni", log::LevelFilter::Off)
+                .build();
+
             android_logger::init_once(
-                android_logger::Config::default().with_min_level(log::Level::Trace),
+                android_logger::Config::default()
+                    .with_min_level(log::Level::Trace)
+                    .with_filter(log_filter),
             );
             crate::android::init_hosted(env, cx).unwrap();
             std::panic::set_hook(Box::new(|info| {
@@ -76,7 +82,7 @@ mod android {
         .unwrap()
     }
 
-    #[export_name = "Java_rustls_platformverifier_android_CertificateVerifierTests_mockTests"]
+    #[export_name = "Java_org_rustls_platformverifier_CertificateVerifierTests_mockTests"]
     pub extern "C" fn rustls_platform_verifier_mock_test_suite(
         env: JNIEnv,
         _class: JClass,
@@ -93,7 +99,7 @@ mod android {
         .into_inner()
     }
 
-    #[export_name = "Java_rustls_platformverifier_android_CertificateVerifierTests_verifyMockRootUsage"]
+    #[export_name = "Java_org_rustls_platformverifier_CertificateVerifierTests_verifyMockRootUsage"]
     pub extern "C" fn rustls_platform_verifier_verify_mock_root_usage(
         env: JNIEnv,
         _class: JClass,
@@ -110,7 +116,7 @@ mod android {
         .into_inner()
     }
 
-    #[export_name = "Java_rustls_platformverifier_android_CertificateVerifierTests_realWorldTests"]
+    #[export_name = "Java_org_rustls_platformverifier_CertificateVerifierTests_realWorldTests"]
     pub extern "C" fn rustls_platform_verifier_real_world_test_suite(
         env: JNIEnv,
         _class: JClass,

--- a/src/verification/android.rs
+++ b/src/verification/android.rs
@@ -12,7 +12,7 @@ use crate::android::{with_context, CachedClass};
 use crate::verification::invalid_certificate;
 
 static CERT_VERIFIER_CLASS: CachedClass =
-    CachedClass::new("rustls/platformverifier/android/CertificateVerifier");
+    CachedClass::new("org/rustls/platformverifier/CertificateVerifier");
 
 // Find the `ByteArray (Uint8 [])` class.
 static BYTE_ARRAY_CLASS: CachedClass = CachedClass::new("[B");
@@ -157,7 +157,7 @@ impl Verifier {
                 'J',
                 "[[B",
                 ')',
-                "Lrustls/platformverifier/android/VerificationResult;"
+                "Lorg/rustls/platformverifier/VerificationResult;"
             );
 
             let result = env


### PR DESCRIPTION
This PR does three things, all related to Android builds:
- Updates the Android component to support AGP 8 (and Gradle 8) by resolving the outstanding incompatibility warnings and fixing build errors found in Android Studio Hedgehog + AGP 8.
- Renamed the package to be more consistent with other open source packages, matching the "conventional" format of a reverse DNS name.
- Fixes a number of typos and other Kotlin warnings that were present.

As of these changes, there are no more Gradle warnings:
```terminal
./gradlew build --warning-mode all

> Task :rustls-platform-verifier:lintReportDebug
Wrote HTML report to file:///Users/User/dev/github/rustls-platform-verifier/android/rustls-platform-verifier/build/reports/lint-results-debug.html

BUILD SUCCESSFUL in 5s
69 actionable tasks: 7 executed, 62 up-to-date
```