### PR TITLE
misc. dependency updates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,8 @@
 on:
   push:
     branches:
-    - main
+      - main
+      - "*_dev"
   pull_request:
 
 name: CI

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /target
 .DS_Store
+/.idea

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -547,7 +547,7 @@ checksum = "07180898a28ed6a7f7ba2311594308f595e3dd2e3c3812fa0a80a47b45f17e5d"
 dependencies = [
  "log",
  "ring",
- "rustls-webpki",
+ "rustls-webpki 0.100.1",
  "sct",
 ]
 
@@ -586,7 +586,7 @@ dependencies = [
  "reqwest",
  "rustls",
  "rustls-native-certs",
- "rustls-webpki",
+ "rustls-webpki 0.101.4",
  "security-framework",
  "security-framework-sys",
  "tokio",
@@ -599,6 +599,16 @@ name = "rustls-webpki"
 version = "0.100.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6207cd5ed3d8dca7816f8f3725513a34609c0c765bf652b8c3cb4cfd87db46b"
+dependencies = [
+ "ring",
+ "untrusted",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.101.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d93931baf2d282fff8d3a532bbfd7653f734643161b87e3e01e59a04439bf0d"
 dependencies = [
  "ring",
  "untrusted",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -999,12 +999,9 @@ dependencies = [
 
 [[package]]
 name = "webpki-roots"
-version = "0.23.0"
+version = "0.25.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa54963694b65584e170cf5dc46aeb4dcaa5584e652ff5f3952e56d66aff0125"
-dependencies = [
- "rustls-webpki",
-]
+checksum = "14247bb57be4f377dfb94c72830b8ce8fc6beac03cf4bf7b9732eadd414123fc"
 
 [[package]]
 name = "winapi"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13,15 +13,15 @@ dependencies = [
 
 [[package]]
 name = "android_log-sys"
-version = "0.2.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85965b6739a430150bdd138e2374a98af0c3ee0d030b3bb7fc3bddff58d0102e"
+checksum = "5ecc8056bf6ab9892dcd53216c83d1597487d7dacac16c8df6b877d127df9937"
 
 [[package]]
 name = "android_logger"
-version = "0.11.3"
+version = "0.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8619b80c242aa7bd638b5c7ddd952addeecb71f69c75e33f1d47b2804f8f883a"
+checksum = "c494134f746c14dc653a35a4ea5aca24ac368529da5370ecf41fe0341c35772f"
 dependencies = [
  "android_log-sys",
  "env_logger",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -541,13 +541,13 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.21.0"
+version = "0.21.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07180898a28ed6a7f7ba2311594308f595e3dd2e3c3812fa0a80a47b45f17e5d"
+checksum = "1d1feddffcfcc0b33f5c6ce9a29e341e4cd59c3f78e7ee45f4a40c038b1d6cbb"
 dependencies = [
  "log",
  "ring",
- "rustls-webpki 0.100.1",
+ "rustls-webpki",
  "sct",
 ]
 
@@ -586,22 +586,12 @@ dependencies = [
  "reqwest",
  "rustls",
  "rustls-native-certs",
- "rustls-webpki 0.101.4",
+ "rustls-webpki",
  "security-framework",
  "security-framework-sys",
  "tokio",
  "webpki-roots",
  "winapi",
-]
-
-[[package]]
-name = "rustls-webpki"
-version = "0.100.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6207cd5ed3d8dca7816f8f3725513a34609c0c765bf652b8c3cb4cfd87db46b"
-dependencies = [
- "ring",
- "untrusted",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -37,12 +37,6 @@ checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
 name = "base64"
-version = "0.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
-
-[[package]]
-name = "base64"
 version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4a4ddaa51a5bc52a6948f74c06d20aaaddb71924eab79b8c97a8c556e942d6a"
@@ -498,7 +492,7 @@ version = "0.11.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cde824a14b7c14f85caff81225f411faacc04a2013f41670f41443742b1c1c55"
 dependencies = [
- "base64 0.21.0",
+ "base64",
  "bytes",
  "encoding_rs",
  "futures-core",
@@ -575,7 +569,7 @@ version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d194b56d58803a43635bdc398cd17e383d6f71f9182b9a192c127ca42494a59b"
 dependencies = [
- "base64 0.21.0",
+ "base64",
 ]
 
 [[package]]
@@ -583,7 +577,7 @@ name = "rustls-platform-verifier"
 version = "0.1.0"
 dependencies = [
  "android_logger",
- "base64 0.13.1",
+ "base64",
  "core-foundation",
  "core-foundation-sys",
  "jni",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,11 +47,11 @@ once_cell = { version = "1.9", optional = true } # Only used during doc generati
 rustls-native-certs = "0.6"
 once_cell = "1.9"
 webpki-roots = "0.25" # Augmentation to `openssl-probe` due to inconsistencies on Linux distros.
-webpki = { package = "rustls-webpki", version = "0.100.0", features = ["alloc", "std"] }
+webpki = { package = "rustls-webpki", version = "0.101", features = ["alloc", "std"] }
 
 [target.'cfg(target_os = "android")'.dependencies]
 jni = { version = "0.19", default-features = false }
-webpki = { package = "rustls-webpki", version = "0.100.0", features = ["alloc", "std"] }
+webpki = { package = "rustls-webpki", version = "0.101", features = ["alloc", "std"] }
 once_cell = "1.9"
 android_logger = { version = "0.11", optional = true } # Only used during testing.
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,7 +53,7 @@ webpki = { package = "rustls-webpki", version = "0.101", features = ["alloc", "s
 jni = { version = "0.19", default-features = false }
 webpki = { package = "rustls-webpki", version = "0.101", features = ["alloc", "std"] }
 once_cell = "1.9"
-android_logger = { version = "0.11", optional = true } # Only used during testing.
+android_logger = { version = "0.13", optional = true } # Only used during testing.
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 once_cell = "1.9"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,7 +39,7 @@ docsrs = ["jni", "once_cell"]
 [dependencies]
 rustls = { version = "0.21", features = ["dangerous_configuration", "tls12", "logging"] }
 log = { version = "0.4" }
-base64 = { version = "0.13", optional = true } # Only used when the `cert-logging` feature is enabled.
+base64 = { version = "0.21", optional = true } # Only used when the `cert-logging` feature is enabled.
 jni = { version = "0.19", default-features = false, optional = true } # Only used during doc generation
 once_cell = { version = "1.9", optional = true } # Only used during doc generation.
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,7 +46,7 @@ once_cell = { version = "1.9", optional = true } # Only used during doc generati
 [target.'cfg(target_os = "linux")'.dependencies]
 rustls-native-certs = "0.6"
 once_cell = "1.9"
-webpki-roots = "0.23" # Augmentation to `openssl-probe` due to inconsistencies on Linux distros.
+webpki-roots = "0.25" # Augmentation to `openssl-probe` due to inconsistencies on Linux distros.
 webpki = { package = "rustls-webpki", version = "0.100.0", features = ["alloc", "std"] }
 
 [target.'cfg(target_os = "android")'.dependencies]
@@ -57,7 +57,7 @@ android_logger = { version = "0.11", optional = true } # Only used during testin
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 once_cell = "1.9"
-webpki-roots = "0.23"
+webpki-roots = "0.25"
 
 [target.'cfg(any(target_os = "macos", target_os = "ios"))'.dependencies]
 core-foundation = "0.9"

--- a/src/tests/ffi.rs
+++ b/src/tests/ffi.rs
@@ -42,7 +42,7 @@ mod android {
 
             android_logger::init_once(
                 android_logger::Config::default()
-                    .with_min_level(log::Level::Trace)
+                    .with_max_level(log::Level::Trace.to_level_filter())
                     .with_filter(log_filter),
             );
             crate::android::init_hosted(env, cx).unwrap();

--- a/src/verification/mod.rs
+++ b/src/verification/mod.rs
@@ -40,7 +40,13 @@ impl std::error::Error for EkuError {}
 // if we need to debug a user's situation.
 fn log_server_cert(_end_entity: &rustls::Certificate) {
     #[cfg(feature = "cert-logging")]
-    log::debug!("verifying certificate: {}", base64::encode(&_end_entity.0));
+    {
+        use base64::Engine;
+        log::debug!(
+            "verifying certificate: {}",
+            base64::engine::general_purpose::STANDARD.encode(&_end_entity.0)
+        );
+    }
 }
 
 #[cfg(any(windows, target_os = "android", target_os = "macos", target_os = "ios"))]

--- a/src/verification/others.rs
+++ b/src/verification/others.rs
@@ -156,7 +156,7 @@ fn map_webpki_errors(err: TlsError) -> TlsError {
 fn load_webpki_roots(store: &mut RootCertStore) {
     use rustls::OwnedTrustAnchor;
 
-    store.add_server_trust_anchors(webpki_roots::TLS_SERVER_ROOTS.iter().map(|root| {
+    store.add_trust_anchors(webpki_roots::TLS_SERVER_ROOTS.iter().map(|root| {
         OwnedTrustAnchor::from_subject_spki_name_constraints(
             root.subject,
             root.spki,

--- a/src/verification/others.rs
+++ b/src/verification/others.rs
@@ -156,7 +156,7 @@ fn map_webpki_errors(err: TlsError) -> TlsError {
 fn load_webpki_roots(store: &mut RootCertStore) {
     use rustls::OwnedTrustAnchor;
 
-    store.add_server_trust_anchors(webpki_roots::TLS_SERVER_ROOTS.0.iter().map(|root| {
+    store.add_server_trust_anchors(webpki_roots::TLS_SERVER_ROOTS.iter().map(|root| {
         OwnedTrustAnchor::from_subject_spki_name_constraints(
             root.subject,
             root.spki,


### PR DESCRIPTION
Before diving into more meaningful work I wanted to update some dependencies (_possibly a good time to consider adding a Dependabot config?_). This branch updates all of the deps and dev deps (with the exception of `jni` (see https://github.com/rustls/rustls-platform-verifier/issues/22), and semver compatible dependencies). Likely easiest to review commit-by-commit.

Additionally rolls in a small `.gitignore` tweak for CLion users and a tweak to the CI config to make it easier to run CI without opening a PR or making config changes.