### PR TITLE
Expose Verifier in API, remove Linux webpki-roots dependency.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,7 +46,6 @@ once_cell = { version = "1.9", optional = true } # Only used during doc generati
 [target.'cfg(target_os = "linux")'.dependencies]
 rustls-native-certs = "0.6"
 once_cell = "1.9"
-webpki-roots = "0.25" # Augmentation to `openssl-probe` due to inconsistencies on Linux distros.
 webpki = { package = "rustls-webpki", version = "0.101", features = ["alloc", "std"] }
 
 [target.'cfg(target_os = "android")'.dependencies]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,7 +6,7 @@ use rustls::ClientConfig;
 use std::sync::Arc;
 
 mod verification;
-use verification::Verifier;
+pub use verification::Verifier;
 
 // Build the Android module when generating docs so that
 // the Android-specific functions are included.
@@ -28,7 +28,8 @@ mod tests;
 pub use tests::ffi::*;
 
 /// Creates and returns a `rustls` configuration that verifies TLS
-/// certificates in the best way for the underlying OS platform.
+/// certificates in the best way for the underlying OS platform, using
+/// safe defaults for the `rustls` configuration.
 ///
 /// # Example
 ///
@@ -45,6 +46,10 @@ pub use tests::ffi::*;
 ///     let _response = client.get("https://example.com").send().await;
 /// }
 /// ```
+///
+/// If you require more control over the rustls `ClientConfig`, you can
+/// instantiate a [Verifier] with [Verifier::default] and then use it
+/// with [rustls::ConfigBuilder::with_custom_certificate_verifier].
 ///
 /// Refer to the crate level documentation to see what platforms
 /// are currently supported.

--- a/src/verification/android.rs
+++ b/src/verification/android.rs
@@ -35,6 +35,7 @@ enum VerifierStatus {
 // official recommendation. See https://bugs.chromium.org/p/chromium/issues/detail?id=627154.
 const AUTH_TYPE: &str = "RSA";
 
+#[derive(Default)]
 pub struct Verifier {
     /// Testing only: The root CA certificate to trust.
     #[cfg(any(test, feature = "ffi-testing"))]

--- a/src/verification/android.rs
+++ b/src/verification/android.rs
@@ -64,7 +64,7 @@ impl Verifier {
     }
 
     #[cfg(any(test, feature = "ffi-testing"))]
-    pub fn new_with_fake_root(root: &[u8]) -> Self {
+    pub(crate) fn new_with_fake_root(root: &[u8]) -> Self {
         Self {
             test_only_root_ca_override: Some(root.into()),
         }

--- a/src/verification/android.rs
+++ b/src/verification/android.rs
@@ -70,7 +70,7 @@ impl Verifier {
         }
     }
 
-    pub fn verify_certificate(
+    fn verify_certificate(
         &self,
         end_entity: &rustls::Certificate,
         intermediates: &[rustls::Certificate],

--- a/src/verification/android.rs
+++ b/src/verification/android.rs
@@ -35,6 +35,7 @@ enum VerifierStatus {
 // official recommendation. See https://bugs.chromium.org/p/chromium/issues/detail?id=627154.
 const AUTH_TYPE: &str = "RSA";
 
+/// A TLS certificate verifier that utilizes the Android platform verifier.
 #[derive(Default)]
 pub struct Verifier {
     /// Testing only: The root CA certificate to trust.
@@ -56,6 +57,8 @@ impl Drop for Verifier {
 }
 
 impl Verifier {
+    /// Creates a new instance of a TLS certificate verifier that utilizes the
+    /// Android certificate facilities
     pub fn new() -> Self {
         Self {
             #[cfg(any(test, feature = "ffi-testing"))]
@@ -63,6 +66,7 @@ impl Verifier {
         }
     }
 
+    /// Creates a test-only TLS certificate verifier which trusts our fake root CA cert.
     #[cfg(any(test, feature = "ffi-testing"))]
     pub(crate) fn new_with_fake_root(root: &[u8]) -> Self {
         Self {

--- a/src/verification/apple.rs
+++ b/src/verification/apple.rs
@@ -37,6 +37,7 @@ fn system_time_to_cfdate(time: SystemTime) -> Result<CFDate, TlsError> {
         .map(|epoch| CFDate::new(epoch.as_secs() as f64))
 }
 
+/// A TLS certificate verifier that utilizes the Apple platform certificate facilities.
 #[derive(Default)]
 pub struct Verifier {
     /// Testing only: The root CA certificate to trust.

--- a/src/verification/others.rs
+++ b/src/verification/others.rs
@@ -2,8 +2,9 @@ use super::log_server_cert;
 use once_cell::sync::OnceCell;
 use rustls::{
     client::{ServerCertVerifier, WebPkiVerifier},
-    CertificateError, Error as TlsError, RootCertStore,
+    CertificateError, Error as TlsError,
 };
+use std::sync::Mutex;
 
 /// A TLS certificate verifier that uses the system's root store and WebPKI.
 #[derive(Default)]
@@ -17,6 +18,10 @@ pub struct Verifier {
     // that might have been made since.
     inner: OnceCell<WebPkiVerifier>,
 
+    // Extra trust anchors to add to the verifier above and beyond those provided by the
+    // platform via rustls-native-certs.
+    extra_roots: Mutex<Vec<rustls::OwnedTrustAnchor>>,
+
     /// Testing only: an additional root CA certificate to trust.
     #[cfg(any(test, feature = "ffi-testing", feature = "dbg"))]
     test_only_root_ca_override: Option<Vec<u8>>,
@@ -24,10 +29,23 @@ pub struct Verifier {
 
 impl Verifier {
     /// Creates a new verifier whose certificate validation is provided by
-    /// WebPKI.
+    /// WebPKI, using root certificates provided by the platform.
     pub fn new() -> Self {
         Self {
             inner: OnceCell::new(),
+            extra_roots: Vec::new().into(),
+            #[cfg(any(test, feature = "ffi-testing", feature = "dbg"))]
+            test_only_root_ca_override: None,
+        }
+    }
+
+    /// Creates a new verifier whose certificate validation is provided by
+    /// WebPKI, using root certificates provided by the platform and augmented by
+    /// the provided extra root certificates.
+    pub fn new_with_extra_roots(roots: impl IntoIterator<Item = rustls::OwnedTrustAnchor>) -> Self {
+        Self {
+            inner: OnceCell::new(),
+            extra_roots: roots.into_iter().collect::<Vec<_>>().into(),
             #[cfg(any(test, feature = "ffi-testing", feature = "dbg"))]
             test_only_root_ca_override: None,
         }
@@ -38,6 +56,7 @@ impl Verifier {
     pub(crate) fn new_with_fake_root(root: &[u8]) -> Self {
         Self {
             inner: OnceCell::new(),
+            extra_roots: Vec::new().into(),
             test_only_root_ca_override: Some(root.into()),
         }
     }
@@ -68,35 +87,42 @@ impl Verifier {
                     log::warn!("Some CA root certificates were ignored due to errors");
                 }
 
-                // While we load webpki-roots anyway, this can be helpful to know for troubleshooting.
                 if root_store.is_empty() {
                     log::error!("No CA certificates were loaded from the system");
+                } else {
+                    log::debug!("Loaded {added} CA certificates from the system");
                 }
 
-                // Finding TLS roots on Linux is not reliable enough to always depend on it
-                // across various distributions. Instead, we always load the WebPKI roots in
-                // addition so that a valid trust anchor is more likely to be available.
-                load_webpki_roots(&mut root_store);
-
-                log::debug!(
-                    "Loaded WebPKI roots in addition to {} roots from the system",
-                    added
-                );
+                // Safety: There's no way for the mutex to be locked multiple times, so this is
+                //         an infallible operation.
+                let mut extra_roots = self.extra_roots.try_lock().unwrap();
+                if !extra_roots.is_empty() {
+                    let count = extra_roots.len();
+                    root_store.add_trust_anchors(&mut extra_roots.drain(..));
+                    log::debug!(
+                        "Loaded {count} extra CA certificates in addition to roots from the system",
+                    );
+                }
             }
             Err(err) => {
                 // This only contains a path to a system directory:
-                // https://github.com/rustls/rustls-native-certs/blob/main/src/lib.rs#L71
-                log::error!(
-                    "No CA certificates were loaded: {}. Falling back to WebPKI roots",
-                    err,
-                );
-                load_webpki_roots(&mut root_store);
+                // https://github.com/rustls/rustls-native-certs/blob/bc13b9a6bfc2e1eec881597055ca49accddd972a/src/lib.rs#L91-L94
+                return Err(rustls::Error::General(format!(
+                    "failed to load system root certificates: {}",
+                    err
+                )));
             }
         };
 
         #[cfg(target_arch = "wasm32")]
         {
-            load_webpki_roots(&mut root_store);
+            root_store.add_trust_anchors(webpki_roots::TLS_SERVER_ROOTS.iter().map(|root| {
+                rustls::OwnedTrustAnchor::from_subject_spki_name_constraints(
+                    root.subject,
+                    root.spki,
+                    root.name_constraints,
+                )
+            }));
         };
 
         Ok(WebPkiVerifier::new(root_store, None))
@@ -151,17 +177,4 @@ fn map_webpki_errors(err: TlsError) -> TlsError {
     }
 
     err
-}
-
-/// Loads the static `webpki-roots` into the provided certificate store.
-fn load_webpki_roots(store: &mut RootCertStore) {
-    use rustls::OwnedTrustAnchor;
-
-    store.add_trust_anchors(webpki_roots::TLS_SERVER_ROOTS.iter().map(|root| {
-        OwnedTrustAnchor::from_subject_spki_name_constraints(
-            root.subject,
-            root.spki,
-            root.name_constraints,
-        )
-    }));
 }

--- a/src/verification/others.rs
+++ b/src/verification/others.rs
@@ -5,6 +5,7 @@ use rustls::{
     CertificateError, Error as TlsError, RootCertStore,
 };
 
+/// A TLS certificate verifier that uses the system's root store and WebPKI.
 #[derive(Default)]
 pub struct Verifier {
     // We use a `OnceCell` so we only need

--- a/src/verification/windows.rs
+++ b/src/verification/windows.rs
@@ -487,6 +487,7 @@ fn map_trust_error_status(unfiltered_status: DWORD) -> Result<(), TlsError> {
     )))
 }
 
+/// A TLS certificate verifier that utilizes the Windows certificate facilities.
 #[derive(Default)]
 pub struct Verifier {
     /// Testing only: The root CA certificate to trust.


### PR DESCRIPTION
## Description

This branch builds on https://github.com/rustls/rustls-platform-verifier/pull/23 and so should be reviewed commit-by-commit starting at b4db665fec0f24382bbfb9be6bbe6053dc77bf0c - the commits prior to this SHA are from #23.

The set of changes in this branch aim to accomplish two related goals:

1. Making the per-platform `Verifier` struct public, resolving https://github.com/rustls/rustls-platform-verifier/issues/7
2. Removing the Linux platform dependency on `webpki-roots`, replacing it with a new `Verifier::new_with_extra_roots` constructor, resolving https://github.com/rustls/rustls-platform-verifier/issues/12.
Callers can choose to use this constructor to provide roots from `webpki-roots` (or another source) and they will be added to the constructed `RootCertStore` in addition to trust anchors loaded from `rustls-native-certs`.

The `wasm32` target continues to depend on `webpki-roots` since there is no `rustls-native-certs` support for that target.

Resolves #7.
Resolves #12.

### TODO:

* [x] Land #23
* [x] Rebase