### PR TITLE
tests: configure android ffi log filter level.

### DIFF
--- a/src/tests/ffi.rs
+++ b/src/tests/ffi.rs
@@ -37,6 +37,7 @@ mod android {
         // These can't fail, and even if they did, Android will crash the process like we want.
         ANDROID_INIT.call_once(|| {
             let log_filter = android_logger::FilterBuilder::new()
+                .parse("trace")
                 .filter_module("jni", log::LevelFilter::Off)
                 .build();
 


### PR DESCRIPTION
In https://github.com/rustls/rustls-platform-verifier/pull/21 the `android_logger` configured in `tests/ffi.rs` was configured with a log filter, but the filter wasn't configured to accept a log level. The end result is that no log output from the Rust test code was visible in `adb logcat`.

This commit adds a `parse("trace")` invocation to the filter so that trace+ log lines are passed through the filter and visible in `logcat`. See https://docs.rs/android_logger/latest/android_logger/#enabling-logging for more information.

(Thanks to complexspaces for spotting the fix!)