### PR TITLE
verification: enable ip subj. validation on android.

### DIFF
--- a/src/tests/verification_mock/mod.rs
+++ b/src/tests/verification_mock/mod.rs
@@ -72,15 +72,11 @@ macro_rules! no_error {
 const ROOT1: &[u8] = include_bytes!("root1.crt");
 const ROOT1_INT1: &[u8] = include_bytes!("root1-int1.crt");
 const ROOT1_INT1_EXAMPLE_COM_GOOD: &[u8] = include_bytes!("root1-int1-ee_example.com-good.crt");
-#[cfg(any(windows, target_os = "macos", target_os = "linux"))]
 const ROOT1_INT1_LOCALHOST_IPV4_GOOD: &[u8] = include_bytes!("root1-int1-ee_127.0.0.1-good.crt");
-#[cfg(any(windows, target_os = "macos", target_os = "linux"))]
 const ROOT1_INT1_LOCALHOST_IPV6_GOOD: &[u8] = include_bytes!("root1-int1-ee_1-good.crt");
 
 const EXAMPLE_COM: &str = "example.com";
-#[cfg(any(windows, target_os = "macos", target_os = "linux"))]
 const LOCALHOST_IPV4: &str = "127.0.0.1";
-#[cfg(any(windows, target_os = "macos", target_os = "linux"))]
 const LOCALHOST_IPV6: &str = "::1";
 
 #[cfg(any(test, feature = "ffi-testing"))]
@@ -127,35 +123,35 @@ mock_root_test_cases! {
         expected_result: Ok(()),
         other_error: no_error!(),
     },
-    valid_no_stapling_ipv4 [ any(windows, target_os = "macos", target_os = "linux") ] => TestCase {
+    valid_no_stapling_ipv4 [ any(windows, target_os = "android", target_os = "macos", target_os = "linux") ] => TestCase {
         reference_id: LOCALHOST_IPV4,
         chain: &[ROOT1_INT1_LOCALHOST_IPV4_GOOD, ROOT1_INT1],
         stapled_ocsp: None,
         expected_result: Ok(()),
         other_error: no_error!(),
     },
-    valid_no_stapling_ipv6 [ any(windows, target_os = "macos", target_os = "linux") ] => TestCase {
+    valid_no_stapling_ipv6 [ any(windows, target_os = "android", target_os = "macos", target_os = "linux") ] => TestCase {
         reference_id: LOCALHOST_IPV6,
         chain: &[ROOT1_INT1_LOCALHOST_IPV6_GOOD, ROOT1_INT1],
         stapled_ocsp: None,
         expected_result: Ok(()),
         other_error: no_error!(),
     },
-    valid_stapled_good_dns [ any(windows, target_os = "android", target_os = "macos", target_os = "linux") ] => TestCase {
+    valid_stapled_good_dns [ any(windows, target_os = "android", target_os = "android", target_os = "macos", target_os = "linux") ] => TestCase {
         reference_id: EXAMPLE_COM,
         chain: &[ROOT1_INT1_EXAMPLE_COM_GOOD, ROOT1_INT1],
         stapled_ocsp: Some(include_bytes!("root1-int1-ee_example.com-good.ocsp")),
         expected_result: Ok(()),
         other_error: no_error!(),
     },
-    valid_stapled_good_ipv4 [ any(windows, target_os = "macos", target_os = "linux") ] => TestCase {
+    valid_stapled_good_ipv4 [ any(windows, target_os = "android", target_os = "macos", target_os = "linux") ] => TestCase {
         reference_id: LOCALHOST_IPV4,
         chain: &[ROOT1_INT1_LOCALHOST_IPV4_GOOD, ROOT1_INT1],
         stapled_ocsp: Some(include_bytes!("root1-int1-ee_127.0.0.1-good.ocsp")),
         expected_result: Ok(()),
         other_error: no_error!(),
     },
-    valid_stapled_good_ipv6 [ any(windows, target_os = "macos", target_os = "linux") ] => TestCase {
+    valid_stapled_good_ipv6 [ any(windows, target_os = "android", target_os = "macos", target_os = "linux") ] => TestCase {
         reference_id: LOCALHOST_IPV6,
         chain: &[ROOT1_INT1_LOCALHOST_IPV6_GOOD, ROOT1_INT1],
         stapled_ocsp: Some(include_bytes!("root1-int1-ee_1-good.ocsp")),
@@ -173,14 +169,14 @@ mock_root_test_cases! {
         expected_result: Err(TlsError::InvalidCertificate(CertificateError::Revoked)),
         other_error: no_error!(),
     },
-    stapled_revoked_ipv4 [ any(windows, target_os = "macos") ] => TestCase {
+    stapled_revoked_ipv4 [ any(windows, target_os = "android", target_os = "macos") ] => TestCase {
         reference_id: LOCALHOST_IPV4,
         chain: &[include_bytes!("root1-int1-ee_127.0.0.1-revoked.crt"), ROOT1_INT1],
         stapled_ocsp: Some(include_bytes!("root1-int1-ee_127.0.0.1-revoked.ocsp")),
         expected_result: Err(TlsError::InvalidCertificate(CertificateError::Revoked)),
         other_error: no_error!(),
     },
-    stapled_revoked_ipv6 [ any(windows, target_os = "macos") ] => TestCase {
+    stapled_revoked_ipv6 [ any(windows, target_os = "android", target_os = "macos") ] => TestCase {
         reference_id: LOCALHOST_IPV6,
         chain: &[include_bytes!("root1-int1-ee_1-revoked.crt"), ROOT1_INT1],
         stapled_ocsp: Some(include_bytes!("root1-int1-ee_1-revoked.ocsp")),
@@ -199,14 +195,14 @@ mock_root_test_cases! {
         expected_result: Err(TlsError::InvalidCertificate(CertificateError::UnknownIssuer)),
         other_error: no_error!(),
     },
-    ee_only_ipv4 [ any(windows, target_os = "macos", target_os = "linux") ] => TestCase {
+    ee_only_ipv4 [ any(windows, target_os = "android", target_os = "macos", target_os = "linux") ] => TestCase {
         reference_id: LOCALHOST_IPV4,
         chain: &[ROOT1_INT1_LOCALHOST_IPV4_GOOD],
         stapled_ocsp: None,
         expected_result: Err(TlsError::InvalidCertificate(CertificateError::UnknownIssuer)),
         other_error: no_error!(),
     },
-    ee_only_ipv6 [ any(windows, target_os = "macos", target_os = "linux") ] => TestCase {
+    ee_only_ipv6 [ any(windows, target_os = "android", target_os = "macos", target_os = "linux") ] => TestCase {
         reference_id: LOCALHOST_IPV6,
         chain: &[ROOT1_INT1_LOCALHOST_IPV6_GOOD],
         stapled_ocsp: None,
@@ -221,14 +217,14 @@ mock_root_test_cases! {
         expected_result: Err(TlsError::InvalidCertificate(CertificateError::NotValidForName)),
         other_error: no_error!(),
     },
-    domain_mismatch_ipv4 [ any(windows, target_os = "macos", target_os = "linux") ] => TestCase {
+    domain_mismatch_ipv4 [ any(windows, target_os = "android", target_os = "macos", target_os = "linux") ] => TestCase {
         reference_id: "198.168.0.1",
         chain: &[ROOT1_INT1_LOCALHOST_IPV4_GOOD, ROOT1_INT1],
         stapled_ocsp: None,
         expected_result: Err(TlsError::InvalidCertificate(CertificateError::NotValidForName)),
         other_error: no_error!(),
     },
-    domain_mismatch_ipv6 [ any(windows, target_os = "macos", target_os = "linux") ] => TestCase {
+    domain_mismatch_ipv6 [ any(windows, target_os = "android", target_os = "macos", target_os = "linux") ] => TestCase {
         reference_id: "::ffff:c6a8:1",
         chain: &[ROOT1_INT1_LOCALHOST_IPV6_GOOD, ROOT1_INT1],
         stapled_ocsp: None,
@@ -243,7 +239,7 @@ mock_root_test_cases! {
             CertificateError::Other(Arc::from(EkuError)))),
         other_error: Some(EkuError),
     },
-    wrong_eku_ipv4 [ any(windows, target_os = "macos", target_os = "linux") ] => TestCase {
+    wrong_eku_ipv4 [ any(windows, target_os = "android", target_os = "macos", target_os = "linux") ] => TestCase {
         reference_id: LOCALHOST_IPV4,
         chain: &[include_bytes!("root1-int1-ee_127.0.0.1-wrong_eku.crt"), ROOT1_INT1],
         stapled_ocsp: None,
@@ -251,7 +247,7 @@ mock_root_test_cases! {
             CertificateError::Other(Arc::from(EkuError)))),
         other_error: Some(EkuError),
     },
-    wrong_eku_ipv6 [ any(windows, target_os = "macos", target_os = "linux") ] => TestCase {
+    wrong_eku_ipv6 [ any(windows, target_os = "android", target_os = "macos", target_os = "linux") ] => TestCase {
         reference_id: LOCALHOST_IPV6,
         chain: &[include_bytes!("root1-int1-ee_1-wrong_eku.crt"), ROOT1_INT1],
         stapled_ocsp: None,

--- a/src/verification/mod.rs
+++ b/src/verification/mod.rs
@@ -57,7 +57,7 @@ fn unsupported_server_name() -> rustls::Error {
 
 // Unknown certificate error shorthand. Used when we need to construct an "Other" certificate
 // error with a platform specific error message.
-#[cfg(any(windows, target_os = "android", target_os = "macos", target_os = "ios"))]
+#[cfg(any(windows, target_os = "macos", target_os = "ios"))]
 fn invalid_certificate(reason: impl Into<String>) -> rustls::Error {
     rustls::Error::InvalidCertificate(rustls::CertificateError::Other(std::sync::Arc::from(
         Box::from(reason.into()),


### PR DESCRIPTION
While the Android verifier defers to the platform verifier for most certificate validation options, it relies on `webpki` for ensuring that a certificate is valid for a given subject name. Since Webpki v0.100.x it's been possible to use `webpki` to validate IP address subject names, and so we want this capability to be enabled for the Android verifier.

This commit updates the Android `verifier` to accomplish this. Additionally it enables the mock IP address subject test cases in the mock test suite to ensure things work as expected.

In order to support this change the function signature of the inner `Verifier.verify_certificate` fn has to change from accepting a `&str` server name, to also accepting the `&rustls::ServerName` that the trait based `ServerCertVerifier.verify_server_cert` was already accepting. There are two main reasons for this:

1. If we try to pull out a `String` to pass forward from the `rustls::ServerName::IpAddress(&IpAddr)` using `IpAddr.to_string()` we'll get back a "compressed" address for IPv6 addresses. This is problematic when later trying to convert to a `webpki::IpAddrRef` for the validation call using `IpAddrRef::try_from_ascii_str`, because it doesn't support the compressed form.
2. By passing through the `rustls::ServerName` directly we can defer the actual process of interacting with `webpki` to the newly exposed [`rustls::client::verify_server_name` fn](https://docs.rs/rustls/latest/rustls/client/fn.verify_server_name.html) offered with the `dangerous_configuration` feature. This will ensure the logic for name validation is applied consistently between Rustls and the platform verifier. It also allows removing the Android specific `pki_name_error` helper, and the Android target's usage of the general `crate::verification::invalid_certificate` helper.

Resolves #15 