### PR TITLE
ci: fix deprecations, MSRV tests.

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,2 +1,3 @@
 [alias]
 clippy-ci = "clippy --all-features --all-targets --all"
+clippy-msrv-ci = "clippy --all-features --lib --all" # Only check --lib target w/ MSRV toolchain.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,18 +79,18 @@ jobs:
           rustup target add aarch64-linux-android
 
       - name: Clippy (${{ matrix.os }})
-        run: cargo clippy-ci
+        run: cargo clippy-msrv-ci
 
       - name: Clippy (Android)
         if: matrix.os == 'ubuntu-latest'
         run: |
-          cargo ndk -t arm64-v8a clippy-ci 
+          cargo ndk -t arm64-v8a clippy-msrv-ci
 
       - name: Clippy (iOS)
         if: matrix.os == 'macos-latest'
         run: |
           rustup target add x86_64-apple-ios
-          cargo clippy-ci  --target x86_64-apple-ios
+          cargo clippy-msrv-ci --target x86_64-apple-ios
 
       # TODO: Consider WASM. See note on "clippy" job.
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,16 +30,13 @@ jobs:
       - uses: actions/checkout@v3
         with:
           persist-credentials: false
-      - uses: actions-rs/toolchain@v1
+      - uses: dtolnay/rust-toolchain@master
         with:
-          profile: minimal
           toolchain: ${{ matrix.rust }}
           components: clippy
 
       - name: Clippy (${{ matrix.os }})
-        uses: actions-rs/cargo@v1
-        with:
-          command: clippy-ci
+        run: cargo clippy-ci
 
       - name: Clippy (Android)
         if: matrix.os == 'ubuntu-latest'
@@ -74,15 +71,11 @@ jobs:
       - uses: actions/checkout@v3
         with:
           persist-credentials: false
-      - uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: stable
-    
+
+      - uses: dtolnay/rust-toolchain@stable
+
       - name: Test (${{ matrix.os }})
-        uses: actions-rs/cargo@v1
-        with:
-          command: test
+        run: cargo test
 
       - name: Setup Android test environment
         uses: actions/setup-java@v2
@@ -137,15 +130,10 @@ jobs:
       - uses: actions/checkout@v3
         with:
           persist-credentials: false
-      - uses: actions-rs/toolchain@v1
+      - uses: dtolnay/rust-toolchain@stable
         with:
-          profile: minimal
-          toolchain: stable
           components: rustfmt
-      - uses: actions-rs/cargo@v1
-        with:
-          command: fmt
-          args: --all -- --check
+      - run: cargo fmt --all -- --check
   
   android_fmt:
     name: Ktlint

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,18 +22,13 @@ jobs:
           - ubuntu-latest
           - macos-latest
           - windows-latest
-        rust:
-          - stable
-          # MSRV
-          - 1.56.0
     steps:
       - uses: actions/checkout@v3
         with:
           persist-credentials: false
 
-      - uses: dtolnay/rust-toolchain@master
+      - uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: ${{ matrix.rust }}
           components: clippy
 
       - name: Clippy (${{ matrix.os }})
@@ -58,6 +53,46 @@ jobs:
       #   run: |
       #     rustup target add wasm32-unknown-unknown
       #     cargo clippy-ci --target wasm32-unknown-unknown
+
+  clippy-msrv:
+    name: Clippy (MSRV)
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os:
+          - ubuntu-latest
+          - macos-latest
+          - windows-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          persist-credentials: false
+
+      - uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: "1.56.0" # MSRV
+          components: clippy
+
+      - name: Install cargo-ndk.
+        run: |
+          cargo install cargo-ndk
+          rustup target add aarch64-linux-android
+
+      - name: Clippy (${{ matrix.os }})
+        run: cargo clippy-ci
+
+      - name: Clippy (Android)
+        if: matrix.os == 'ubuntu-latest'
+        run: |
+          cargo ndk -t arm64-v8a clippy-ci 
+
+      - name: Clippy (iOS)
+        if: matrix.os == 'macos-latest'
+        run: |
+          rustup target add x86_64-apple-ios
+          cargo clippy-ci  --target x86_64-apple-ios
+
+      # TODO: Consider WASM. See note on "clippy" job.
 
   test:
     name: Test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,7 +75,7 @@ jobs:
 
       - name: Install cargo-ndk.
         run: |
-          cargo install cargo-ndk
+          cargo install cargo-ndk --version 2.12.7
           rustup target add aarch64-linux-android
 
       - name: Clippy (${{ matrix.os }})

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,8 @@ on:
       - main
       - "*_dev"
   pull_request:
+  schedule:
+    - cron: '0 18 * * *'
 
 name: CI
 permissions:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           persist-credentials: false
+
       - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ matrix.rust }}
@@ -130,9 +131,11 @@ jobs:
       - uses: actions/checkout@v3
         with:
           persist-credentials: false
+
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: rustfmt
+
       - run: cargo fmt --all -- --check
   
   android_fmt:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,7 @@ on:
       - main
       - "*_dev"
   pull_request:
+  merge_group:
   schedule:
     - cron: '0 18 * * *'
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,7 +70,7 @@ jobs:
 
       - uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: "1.56.0" # MSRV
+          toolchain: "1.64.0" # MSRV
           components: clippy
 
       - name: Install cargo-ndk.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ keywords = ["tls", "certificate", "verification", "os", "native"]
 repository = "https://github.com/1Password/rustls-platform-verifier"
 license = "MIT OR Apache-2.0"
 edition = "2021"
-rust-version = "1.56"
+rust-version = "1.64.0"
 
 exclude = [
     "android/.run",

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![crates.io version](https://img.shields.io/crates/v/rustls-platform-verifier.svg)](https://crates.io/crates/rustls-platform-verifier)
 [![crate documentation](https://docs.rs/rustls-platform-verifier/badge.svg)](https://docs.rs/rustls-platform-verifier)
-![MSRV](https://img.shields.io/badge/rustc-1.56+-blue.svg)
+![MSRV](https://img.shields.io/badge/rustc-1.64+-blue.svg)
 [![crates.io downloads](https://img.shields.io/crates/d/rustls-platform-verifier.svg)](https://crates.io/crates/rustls-platform-verifier)
 ![CI](https://github.com/1Password/rustls-platform-verifier/workflows/CI/badge.svg)
 

--- a/src/verification/android.rs
+++ b/src/verification/android.rs
@@ -248,7 +248,7 @@ fn extract_result_info(env: &JNIEnv<'_>, result: JObject<'_>) -> (VerifierStatus
     let msg = env
         .get_field(result, "message", "Ljava/lang/String;")
         .and_then(|m| m.l())
-        .map(|o| (!o.is_null()).then(|| o))
+        .map(|o| (!o.is_null()).then_some(o))
         .and_then(|s| s.map(|s| JavaStr::from_env(env, s.into())).transpose())
         .unwrap();
 

--- a/src/verification/windows.rs
+++ b/src/verification/windows.rs
@@ -184,7 +184,7 @@ impl Certificate {
                 CERT_SET_PROPERTY_IGNORE_PERSIST_ERROR_FLAG,
                 prop_data,
             ) == TRUE)
-                .then(|| ())
+                .then_some(())
         })
     }
 }


### PR DESCRIPTION
## Description

This branch resolves the remaining GitHub warnings from the `actions-rs` tasks. It also appears that the MSRV related tests weren't working properly in CI, masking some failures that were uncovered with the switch to `dtolnay/rust-toolchain`.

I recommend reviewing this commit-by-commit. The top-level highlights:

1. replaces actions-rs with dtolnay/rust-toolchain.
1. splits out a MSRV clippy job so we can customize it more easily.
1. adds a MSRV-specific clippy alias to only test the `--lib` target.
1. changes the project MSRV from 1.56 -> 1.64 based on [our experiences](https://github.com/rustls/rustls-platform-verifier/pull/30#discussion_r1313613280) trying to get a workable solution for `cargo ndk` and transitive deps.
1. switches the MSRV clippy job to use cargo-ndk 2.12.7, the latest release compatible with a MSRV of 1.64.
1. fixes some unnecessary lazy evaluations clippy findings.
1. adds a cron trigger and support for the merge queue feature.

Resolves https://github.com/rustls/rustls-platform-verifier/issues/26


