### PR TITLE
Add Android release artifact stripping and verification

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -159,3 +159,14 @@ jobs:
         run: |
           cd ./android
           ./gradlew ktlint
+
+  verify_android:
+    name: Verify Android artifacts
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          persist-credentials: false
+      
+      - name: Verify release artifact
+        run: ./ci/verify_android_release.sh

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 /target
 .DS_Store
 /.idea
+
+/android/verification/

--- a/android/rustls-platform-verifier/build.gradle
+++ b/android/rustls-platform-verifier/build.gradle
@@ -39,7 +39,8 @@ android {
 
     buildTypes {
         release {
-            minifyEnabled false
+            minifyEnabled true
+            proguardFiles "proguard-rules.pro"
         }
 
         debug {

--- a/android/rustls-platform-verifier/build.gradle
+++ b/android/rustls-platform-verifier/build.gradle
@@ -3,6 +3,8 @@ plugins {
     id 'org.jetbrains.kotlin.android'
 }
 
+def isTest = gradle.startParameter.taskNames.any { it.contains("Test") }
+
 static def getOsArch() {
     final String hostArch = System.getProperty("os.arch")
 
@@ -27,6 +29,8 @@ android {
     defaultConfig {
         minSdk 22
         targetSdk 33
+
+        buildConfigField "boolean", "TEST", "$isTest"
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }

--- a/android/rustls-platform-verifier/proguard-rules.pro
+++ b/android/rustls-platform-verifier/proguard-rules.pro
@@ -1,0 +1,41 @@
+# Add project specific ProGuard rules here.
+# You can control the set of applied configuration files using the
+# proguardFiles setting in build.gradle.
+#
+# For more details, see
+#   http://developer.android.com/guide/developing/tools/proguard.html
+
+-keepattributes SourceFile,LineNumberTable,MethodAttributes
+# Everything is called via the JNI, so code must not be removed or renamed
+# in a way Rust can't see.
+-dontobfuscate
+
+# We need this function (and class) in all builds for Rust to call because its the JNI entrypoint
+# for the verifier functionality.
+-keep class org.rustls.platformverifier.CertificateVerifier {
+    verifyCertificateChain(
+        android.content.Context,
+        java.lang.String,
+        java.lang.String,
+        java.lang.String[],
+        byte[],
+        long,
+        byte[][]
+    );
+}
+
+# We need these classes so Rust can load their class definitions at runtime
+# and access their fields at runtime.
+-keep class org.rustls.platformverifier.StatusCode { *; }
+-keep class org.rustls.platformverifier.VerificationResult { *; }
+
+# Note: We don't explicitly tell Proguard to remove test-only methods. They are instead
+# removed as dead code because `javac` removes all references to them when not building
+# in a test configuration.
+
+# This can be uncommented during development if needed to quickly check if
+# a few test-only methods/fields are being removed by build time.
+# -whyareyoukeeping class org.rustls.platformverifier.CertificateVerifier {
+#   private java.security.KeyStore mockKeystore;
+#    addMockRoot(byte[]);
+#}

--- a/android/rustls-platform-verifier/src/main/java/org/rustls/platformverifier/CertificateVerifier.kt
+++ b/android/rustls-platform-verifier/src/main/java/org/rustls/platformverifier/CertificateVerifier.kt
@@ -105,7 +105,7 @@ internal object CertificateVerifier {
 
     @JvmStatic
     private fun addMockRoot(root: ByteArray) {
-        if (!BuildConfig.DEBUG) {
+        if (!BuildConfig.TEST) {
             throw Exception("attempted to add a mock root outside a test!")
         }
 
@@ -222,10 +222,10 @@ internal object CertificateVerifier {
         // We select them as follows:
         // - If built for release, only use the system trust manager. This should let all test-related
         // code be optimized out.
-        // - If built for debug:
+        // - If built for tests:
         //      - If the mock CA store has any values, use the mock trust manager.
         //      - Otherwise, use the system trust manager.
-        val (trustManager, keystore) = if (!BuildConfig.DEBUG) {
+        val (trustManager, keystore) = if (!BuildConfig.TEST) {
             val trustManager =
                 systemTrustManager.value ?: return VerificationResult(StatusCode.Unavailable)
             Pair(trustManager, systemKeystore)
@@ -256,7 +256,7 @@ internal object CertificateVerifier {
         // TEST ONLY: Mock test suite cannot attempt to check revocation status if no OSCP data has been stapled,
         // because Android requires certificates to an specify OCSP responder for network fetch in this case.
         // If in testing w/o OCSP stapled, short-circuit here - only prior checks apply.
-        if ((mockKeystore.size() != 0) && (ocspResponse == null)) {
+        if (BuildConfig.TEST && (mockKeystore.size() != 0) && (ocspResponse == null)) {
             return VerificationResult(StatusCode.Ok)
         }
 

--- a/ci/verify_android_release.sh
+++ b/ci/verify_android_release.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+
+# This script's purpose is to verify that no test-only code is present inside of the release-mode Android artifact.
+# It is validating that `javac` is performing the dead-code elimiation we expect and that `proguard` is deleting the
+# unreferenced test code. This can be ran both locally and in CI.
+#
+# It accomplishes this goal by building the artifact and then running a decompiler on it to look for names we expect or do not.
+
+set -euo pipefail
+
+mkdir -p ./android/verification
+
+pushd ./android/
+
+./gradlew clean
+./gradlew assembleRelease
+
+pushd ./verification
+
+if [ ! -f "./bin/jadx" ]; then
+    echo "Decompiler not yet installed, downloading jadx"
+    curl -L https://github.com/skylot/jadx/releases/download/v1.4.7/jadx-1.4.7.zip --output jadx.zip
+    unzip jadx.zip
+    echo "jadx downloaded"
+fi
+
+./bin/jadx -d decompiled ../rustls-platform-verifier/build/outputs/aar/rustls-platform-verifier-release.aar
+
+if grep -r -q "mock" ./decompiled; then
+    echo "❌ Test-only code exists in release artifact! Please review changes made to locate the cause".
+    exit 1
+else 
+    echo "✅ No test-only code found in release artifact"
+fi
+
+if grep -r -q "verifyCertificateChain" ./decompiled; then
+    echo "✅ JNI entrypoint present in release artifact"
+else 
+    echo "❌ JNI entrypoint not found in release artifact! Please review changes made to optimization rules which might cause this"
+    exit 1
+fi


### PR DESCRIPTION
This PR's goal is to make sure we are not shipping any test-only code to end users, both for security and code size reasons. Unlike Rust where compile-time code elimination is a first-class feature, more work is required to obtain the same result in Java/Kotlin. In total, there are two parts of making this work:
- Ensuring the Java compiler can remove branches which access test-only methods and fields on the verifier class.
    - We accomplish this by introducing, and switching to, a proper constant into the Android library's `BuildConfig` which can be evaluated at bytecode compile time.
    - With this new true constant, the Java compiler is able to delete our test branches reliably.
- Configuring Proguard/R8 to run on the resulting release artifact to strip out all of the now-unused test-related code.

Additionally, a script was added that can verify the contents of the current artifact configuration. It's also been added to CI here for automatic verification.

To visually confirm this, you can either open the decompiled files generated by the new script in your editor of choice, or you can use a visual Java decompiler. For this PR I used both `jadx-gui` and Android Studio's built-in decompiler to confirm what class parts were present. For example, you can see that every `*mock*` class part is not present anymore:
<img width="379" alt="image" src="https://github.com/rustls/rustls-platform-verifier/assets/68570223/e90b1672-5c61-42dd-8f05-d8d1ad542b51">


Closes #5