### PR TITLE
ci: use --locked for MSRV cargo-ndk install

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,7 +78,7 @@ jobs:
 
       - name: Install cargo-ndk.
         run: |
-          cargo install cargo-ndk --version 2.12.7
+          cargo install cargo-ndk --locked --version 2.12.7
           rustup target add aarch64-linux-android
 
       - name: Clippy (${{ matrix.os }})


### PR DESCRIPTION
A transitive dependency of `cargo-ndk`, `regex-automata`,increased its MSRV and so installing `cargo-ndk` at version 2.12.7 breaks in the MSRV CI task unless we use the pinned `Cargo.lock` version, or upgrade our MSRV in turn.

See https://github.com/rustls/rustls-platform-verifier/pull/30 for previous struggles related to `cargo-ndk` and maintaining a MSRV of 1.64.

Resolves https://github.com/rustls/rustls-platform-verifier/issues/37.