### PR TITLE
Remove crate-level test verifier constructor

### DIFF
--- a/rustls-platform-verifier/src/lib.rs
+++ b/rustls-platform-verifier/src/lib.rs
@@ -60,18 +60,13 @@ pub use tests::ffi::*;
 pub fn tls_config() -> ClientConfig {
     rustls::ClientConfig::builder()
         .with_safe_defaults()
-        .with_custom_certificate_verifier(verifier_for_testing())
+        .with_custom_certificate_verifier(Arc::new(Verifier::new()))
         .with_no_client_auth()
 }
 
-/// Exposed for test usage. Don't use this, use [tls_config] instead.
+/// Exposed for debugging certificate issues with standalone tools.
 ///
-/// This verifier must be exactly equivalent to the verifier used in the `ClientConfig` returned by [tls_config].
-pub(crate) fn verifier_for_testing() -> Arc<dyn rustls::client::ServerCertVerifier> {
-    Arc::new(Verifier::new())
-}
-
-/// Exposed for debugging customer certificate issues. Don't use this, use [tls_config] instead.
+/// This is not intended for production use, you should use [tls_config] instead.
 #[cfg(feature = "dbg")]
 pub fn verifier_for_dbg(root: &[u8]) -> Arc<dyn rustls::client::ServerCertVerifier> {
     Arc::new(Verifier::new_with_fake_root(root))

--- a/rustls-platform-verifier/src/tests/verification_mock/mod.rs
+++ b/rustls-platform-verifier/src/tests/verification_mock/mod.rs
@@ -82,7 +82,7 @@ const LOCALHOST_IPV6: &str = "::1";
 #[cfg(any(test, feature = "ffi-testing"))]
 #[cfg_attr(feature = "ffi-testing", allow(dead_code))]
 pub(super) fn verification_without_mock_root() {
-    let verifier = crate::verifier_for_testing();
+    let verifier = Verifier::new();
 
     let server_name = rustls::client::ServerName::try_from(EXAMPLE_COM).unwrap();
     let end_entity = rustls::Certificate(ROOT1_INT1_EXAMPLE_COM_GOOD.to_vec());

--- a/rustls-platform-verifier/src/tests/verification_real_world/mod.rs
+++ b/rustls-platform-verifier/src/tests/verification_real_world/mod.rs
@@ -42,8 +42,8 @@
 //! Thus we don't expect these tests to be flaky w.r.t. that, except for
 //! potentially poor performance.     
 use super::TestCase;
-use crate::tests::assert_cert_error_eq;
-use rustls::{CertificateError, Error as TlsError};
+use crate::{tests::assert_cert_error_eq, Verifier};
+use rustls::{client::ServerCertVerifier, CertificateError, Error as TlsError};
 use std::convert::TryFrom;
 
 // This is the certificate chain presented by one server for
@@ -124,7 +124,7 @@ macro_rules! no_error {
 fn real_world_test<E: std::error::Error>(test_case: &TestCase<E>) {
     log::info!("verifying {:?}", test_case.expected_result);
 
-    let verifier = crate::verifier_for_testing();
+    let verifier = Verifier::new();
 
     let mut chain = test_case
         .chain


### PR DESCRIPTION
This PR makes a few small cleanup changes before the 0.1 release, which only affect test code. Since the `Verifier` struct became part of the public API, the `verifier_for_testing` function has been redundant and more confusing then helpful.