### PR TITLE
tests: use a fixed SystemTime for certificate validation

### DIFF
--- a/rustls-platform-verifier/src/tests/mod.rs
+++ b/rustls-platform-verifier/src/tests/mod.rs
@@ -2,6 +2,7 @@
 pub mod ffi;
 
 use std::error::Error as StdError;
+use std::time::{Duration, SystemTime};
 
 mod verification_real_world;
 
@@ -18,6 +19,9 @@ struct TestCase<'a, E: StdError> {
 
     /// The stapled OCSP response given to us by Rustls, if any.
     pub stapled_ocsp: Option<&'a [u8]>,
+
+    /// The time to use as the current time for verification.
+    pub verification_time: SystemTime,
 
     pub expected_result: Result<(), TlsError>,
 
@@ -45,4 +49,14 @@ pub fn assert_cert_error_eq<E: StdError + PartialEq + 'static>(
     } else {
         assert_eq!(result, expected);
     }
+}
+
+/// Return a fixed [SystemTime] for certificate validation purposes.
+///
+/// We fix the "now" value used for certificate validation to a fixed point in time at which
+/// we know the test certificates are valid. This must be updated if the mock certificates
+/// are regenerated.
+pub(crate) fn verification_time() -> SystemTime {
+    // Wednesday, January 3, 2024 6:03:08 PM UTC
+    SystemTime::UNIX_EPOCH + Duration::from_secs(1_704_304_988)
 }

--- a/rustls-platform-verifier/src/tests/verification_mock/ca.go
+++ b/rustls-platform-verifier/src/tests/verification_mock/ca.go
@@ -1,5 +1,9 @@
 // Generates the test data files used in the tests in verification_mock.rs.
 //
+// After re-generating mock certificates be sure to also update the fixed
+// verification timestamp in `mod.rs`'s `verification_time` fn to match
+// the current time.
+//
 // The primary point of this program is to fully automate the creation of the
 // test data, with minimal tool dependencies (e.g. no OpenSSL), with low effort.
 //

--- a/rustls-platform-verifier/src/tests/verification_mock/mod.rs
+++ b/rustls-platform-verifier/src/tests/verification_mock/mod.rs
@@ -21,7 +21,7 @@
 ))]
 
 use super::TestCase;
-use crate::tests::assert_cert_error_eq;
+use crate::tests::{assert_cert_error_eq, verification_time};
 use crate::verification::{EkuError, Verifier};
 use rustls::{client::ServerCertVerifier, CertificateError, Error as TlsError};
 use std::convert::TryFrom;
@@ -95,7 +95,7 @@ pub(super) fn verification_without_mock_root() {
         &server_name,
         &mut std::iter::empty(),
         &[],
-        std::time::SystemTime::now(),
+        verification_time(),
     );
 
     assert_eq!(
@@ -120,6 +120,7 @@ mock_root_test_cases! {
         reference_id: EXAMPLE_COM,
         chain: &[ROOT1_INT1_EXAMPLE_COM_GOOD, ROOT1_INT1],
         stapled_ocsp: None,
+        verification_time: verification_time(),
         expected_result: Ok(()),
         other_error: no_error!(),
     },
@@ -127,6 +128,7 @@ mock_root_test_cases! {
         reference_id: LOCALHOST_IPV4,
         chain: &[ROOT1_INT1_LOCALHOST_IPV4_GOOD, ROOT1_INT1],
         stapled_ocsp: None,
+        verification_time: verification_time(),
         expected_result: Ok(()),
         other_error: no_error!(),
     },
@@ -134,6 +136,7 @@ mock_root_test_cases! {
         reference_id: LOCALHOST_IPV6,
         chain: &[ROOT1_INT1_LOCALHOST_IPV6_GOOD, ROOT1_INT1],
         stapled_ocsp: None,
+        verification_time: verification_time(),
         expected_result: Ok(()),
         other_error: no_error!(),
     },
@@ -141,6 +144,7 @@ mock_root_test_cases! {
         reference_id: EXAMPLE_COM,
         chain: &[ROOT1_INT1_EXAMPLE_COM_GOOD, ROOT1_INT1],
         stapled_ocsp: Some(include_bytes!("root1-int1-ee_example.com-good.ocsp")),
+        verification_time: verification_time(),
         expected_result: Ok(()),
         other_error: no_error!(),
     },
@@ -148,6 +152,7 @@ mock_root_test_cases! {
         reference_id: LOCALHOST_IPV4,
         chain: &[ROOT1_INT1_LOCALHOST_IPV4_GOOD, ROOT1_INT1],
         stapled_ocsp: Some(include_bytes!("root1-int1-ee_127.0.0.1-good.ocsp")),
+        verification_time: verification_time(),
         expected_result: Ok(()),
         other_error: no_error!(),
     },
@@ -155,6 +160,7 @@ mock_root_test_cases! {
         reference_id: LOCALHOST_IPV6,
         chain: &[ROOT1_INT1_LOCALHOST_IPV6_GOOD, ROOT1_INT1],
         stapled_ocsp: Some(include_bytes!("root1-int1-ee_1-good.ocsp")),
+        verification_time: verification_time(),
         expected_result: Ok(()),
         other_error: no_error!(),
     },
@@ -166,6 +172,7 @@ mock_root_test_cases! {
         reference_id: EXAMPLE_COM,
         chain: &[include_bytes!("root1-int1-ee_example.com-revoked.crt"), ROOT1_INT1],
         stapled_ocsp: Some(include_bytes!("root1-int1-ee_example.com-revoked.ocsp")),
+        verification_time: verification_time(),
         expected_result: Err(TlsError::InvalidCertificate(CertificateError::Revoked)),
         other_error: no_error!(),
     },
@@ -173,6 +180,7 @@ mock_root_test_cases! {
         reference_id: LOCALHOST_IPV4,
         chain: &[include_bytes!("root1-int1-ee_127.0.0.1-revoked.crt"), ROOT1_INT1],
         stapled_ocsp: Some(include_bytes!("root1-int1-ee_127.0.0.1-revoked.ocsp")),
+        verification_time: verification_time(),
         expected_result: Err(TlsError::InvalidCertificate(CertificateError::Revoked)),
         other_error: no_error!(),
     },
@@ -180,6 +188,7 @@ mock_root_test_cases! {
         reference_id: LOCALHOST_IPV6,
         chain: &[include_bytes!("root1-int1-ee_1-revoked.crt"), ROOT1_INT1],
         stapled_ocsp: Some(include_bytes!("root1-int1-ee_1-revoked.ocsp")),
+        verification_time: verification_time(),
         expected_result: Err(TlsError::InvalidCertificate(CertificateError::Revoked)),
         other_error: no_error!(),
     },
@@ -192,6 +201,7 @@ mock_root_test_cases! {
         reference_id: EXAMPLE_COM,
         chain: &[ROOT1_INT1_EXAMPLE_COM_GOOD],
         stapled_ocsp: None,
+        verification_time: verification_time(),
         expected_result: Err(TlsError::InvalidCertificate(CertificateError::UnknownIssuer)),
         other_error: no_error!(),
     },
@@ -199,6 +209,7 @@ mock_root_test_cases! {
         reference_id: LOCALHOST_IPV4,
         chain: &[ROOT1_INT1_LOCALHOST_IPV4_GOOD],
         stapled_ocsp: None,
+        verification_time: verification_time(),
         expected_result: Err(TlsError::InvalidCertificate(CertificateError::UnknownIssuer)),
         other_error: no_error!(),
     },
@@ -206,6 +217,7 @@ mock_root_test_cases! {
         reference_id: LOCALHOST_IPV6,
         chain: &[ROOT1_INT1_LOCALHOST_IPV6_GOOD],
         stapled_ocsp: None,
+        verification_time: verification_time(),
         expected_result: Err(TlsError::InvalidCertificate(CertificateError::UnknownIssuer)),
         other_error: no_error!(),
     },
@@ -214,6 +226,7 @@ mock_root_test_cases! {
         reference_id: "example.org",
         chain: &[ROOT1_INT1_EXAMPLE_COM_GOOD, ROOT1_INT1],
         stapled_ocsp: None,
+        verification_time: verification_time(),
         expected_result: Err(TlsError::InvalidCertificate(CertificateError::NotValidForName)),
         other_error: no_error!(),
     },
@@ -221,6 +234,7 @@ mock_root_test_cases! {
         reference_id: "198.168.0.1",
         chain: &[ROOT1_INT1_LOCALHOST_IPV4_GOOD, ROOT1_INT1],
         stapled_ocsp: None,
+        verification_time: verification_time(),
         expected_result: Err(TlsError::InvalidCertificate(CertificateError::NotValidForName)),
         other_error: no_error!(),
     },
@@ -228,6 +242,7 @@ mock_root_test_cases! {
         reference_id: "::ffff:c6a8:1",
         chain: &[ROOT1_INT1_LOCALHOST_IPV6_GOOD, ROOT1_INT1],
         stapled_ocsp: None,
+        verification_time: verification_time(),
         expected_result: Err(TlsError::InvalidCertificate(CertificateError::NotValidForName)),
         other_error: no_error!(),
     },
@@ -235,6 +250,7 @@ mock_root_test_cases! {
         reference_id: EXAMPLE_COM,
         chain: &[include_bytes!("root1-int1-ee_example.com-wrong_eku.crt"), ROOT1_INT1],
         stapled_ocsp: None,
+        verification_time: verification_time(),
         expected_result: Err(TlsError::InvalidCertificate(
             CertificateError::Other(Arc::from(EkuError)))),
         other_error: Some(EkuError),
@@ -243,6 +259,7 @@ mock_root_test_cases! {
         reference_id: LOCALHOST_IPV4,
         chain: &[include_bytes!("root1-int1-ee_127.0.0.1-wrong_eku.crt"), ROOT1_INT1],
         stapled_ocsp: None,
+        verification_time: verification_time(),
         expected_result: Err(TlsError::InvalidCertificate(
             CertificateError::Other(Arc::from(EkuError)))),
         other_error: Some(EkuError),
@@ -251,6 +268,7 @@ mock_root_test_cases! {
         reference_id: LOCALHOST_IPV6,
         chain: &[include_bytes!("root1-int1-ee_1-wrong_eku.crt"), ROOT1_INT1],
         stapled_ocsp: None,
+        verification_time: verification_time(),
         expected_result: Err(TlsError::InvalidCertificate(
             CertificateError::Other(Arc::from(EkuError)))),
         other_error: Some(EkuError),
@@ -289,7 +307,7 @@ fn test_with_mock_root<E: std::error::Error + PartialEq + 'static>(test_case: &T
         &server_name,
         &mut std::iter::empty(),
         test_case.stapled_ocsp.unwrap_or(&[]),
-        std::time::SystemTime::now(),
+        test_case.verification_time,
     );
 
     assert_cert_error_eq(

--- a/rustls-platform-verifier/src/tests/verification_real_world/mod.rs
+++ b/rustls-platform-verifier/src/tests/verification_real_world/mod.rs
@@ -41,16 +41,16 @@ use rustls::{client::ServerCertVerifier, CertificateError, Error as TlsError};
 use std::convert::TryFrom;
 
 // This is the certificate chain presented by one server for
-// my.1password.com when this test was updated 2022-09-22. It is
+// my.1password.com when this test was updated 2023-08-01. It is
 // valid for *.1password.com and 1password.com from
-// "Jul 24 00:00:00 2022 GMT" through "Aug 22 23:59:59 2023 GMT".
+// "Jun 24 00:00:00 2023 GMT" through "Jul 22 23:59:59 2024 GMT".
 //
 // Use this to template view the certificate using OpenSSL:
 // ```sh
 // openssl x509 -inform der -text -in 1password_com_valid_1.crt | less
 // ```
 //
-// You can update the cert file with `update_valid_1_cert.bash`
+// You can update the cert file with `update_valid_ee_certs.rs`
 const VALID_1PASSWORD_COM_CHAIN: &[&[u8]] = &[
     include_bytes!("1password_com_valid_1.crt"),
     include_bytes!("1password_com_valid_2.crt"),


### PR DESCRIPTION
Fixing the `SystemTime` that we pass to the certificate verifier for the real world and mock verification tests will ensure that the tests don't start to fail just because the vendored certificates have expired.

[Suggested by @complexspaces](https://github.com/rustls/rustls-platform-verifier/pull/46#issuecomment-1872275559) in https://github.com/rustls/rustls-platform-verifier/pull/46