### PR TITLE
Support FreeBSD

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -162,6 +162,28 @@ jobs:
 
       # TODO: Test iOS in CI too.
 
+  test-freebsd:
+    name: Test (FreeBSD)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: test on freebsd
+        uses: vmactions/freebsd-vm@v1
+        # Settings adopted from https://github.com/quinn-rs/quinn
+        with:
+          usesh: true
+          mem: 4096
+          copyback: false
+          prepare: |
+            pkg install -y curl
+            curl https://sh.rustup.rs -sSf --output rustup.sh
+            sh rustup.sh -y --profile minimal --default-toolchain stable
+            echo "~~~~ rustc --version ~~~~"
+            $HOME/.cargo/bin/rustc --version
+            echo "~~~~ freebsd-version ~~~~"
+            freebsd-version
+          run: $HOME/.cargo/bin/cargo test
+
   fmt:
     name: Rustfmt
     runs-on: ubuntu-latest

--- a/rustls-platform-verifier/Cargo.toml
+++ b/rustls-platform-verifier/Cargo.toml
@@ -35,7 +35,7 @@ base64 = { version = "0.21", optional = true } # Only used when the `cert-loggin
 jni = { version = "0.19", default-features = false, optional = true } # Only used during doc generation
 once_cell = { version = "1.9", optional = true } # Only used during doc generation.
 
-[target.'cfg(target_os = "linux")'.dependencies]
+[target.'cfg(all(unix, not(target_os = "android"), not(target_os = "macos"), not(target_os = "ios")))'.dependencies]
 rustls-native-certs = "0.6"
 once_cell = "1.9"
 webpki = { package = "rustls-webpki", version = "0.101", features = ["alloc", "std"] }
@@ -49,6 +49,10 @@ android_logger = { version = "0.13", optional = true } # Only used during testin
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 once_cell = "1.9"
+webpki-roots = "0.25"
+
+# BSD targets require webpki-roots for the real-world verification tests.
+[target.'cfg(target_os = "freebsd")'.dev-dependencies]
 webpki-roots = "0.25"
 
 [target.'cfg(any(target_os = "macos", target_os = "ios"))'.dependencies]

--- a/rustls-platform-verifier/src/tests/verification_mock/mod.rs
+++ b/rustls-platform-verifier/src/tests/verification_mock/mod.rs
@@ -13,12 +13,7 @@
 //! any parts of the system outside of these tests. See the `#![cfg(...)]`
 //! immediately below to see which platforms run these tests.
 
-#![cfg(any(
-    windows,
-    target_os = "android",
-    target_os = "macos",
-    target_os = "linux"
-))]
+#![cfg(all(any(windows, unix, target_os = "android"), not(target_os = "ios")))]
 
 use super::TestCase;
 use crate::tests::{assert_cert_error_eq, verification_time};
@@ -116,7 +111,7 @@ fn test_verification_without_mock_root() {
 // Verifies that our test trust anchor(s) are not trusted when `Verifier::new()`
 // is used.
 mock_root_test_cases! {
-    valid_no_stapling_dns [ any(windows, target_os = "android", target_os = "macos", target_os = "linux") ] => TestCase {
+    valid_no_stapling_dns [ any(windows, unix) ] => TestCase {
         reference_id: EXAMPLE_COM,
         chain: &[ROOT1_INT1_EXAMPLE_COM_GOOD, ROOT1_INT1],
         stapled_ocsp: None,
@@ -124,7 +119,7 @@ mock_root_test_cases! {
         expected_result: Ok(()),
         other_error: no_error!(),
     },
-    valid_no_stapling_ipv4 [ any(windows, target_os = "android", target_os = "macos", target_os = "linux") ] => TestCase {
+    valid_no_stapling_ipv4 [ any(windows, unix) ] => TestCase {
         reference_id: LOCALHOST_IPV4,
         chain: &[ROOT1_INT1_LOCALHOST_IPV4_GOOD, ROOT1_INT1],
         stapled_ocsp: None,
@@ -132,7 +127,7 @@ mock_root_test_cases! {
         expected_result: Ok(()),
         other_error: no_error!(),
     },
-    valid_no_stapling_ipv6 [ any(windows, target_os = "android", target_os = "macos", target_os = "linux") ] => TestCase {
+    valid_no_stapling_ipv6 [ any(windows, unix) ] => TestCase {
         reference_id: LOCALHOST_IPV6,
         chain: &[ROOT1_INT1_LOCALHOST_IPV6_GOOD, ROOT1_INT1],
         stapled_ocsp: None,
@@ -140,7 +135,7 @@ mock_root_test_cases! {
         expected_result: Ok(()),
         other_error: no_error!(),
     },
-    valid_stapled_good_dns [ any(windows, target_os = "android", target_os = "android", target_os = "macos", target_os = "linux") ] => TestCase {
+    valid_stapled_good_dns [ any(windows, unix) ] => TestCase {
         reference_id: EXAMPLE_COM,
         chain: &[ROOT1_INT1_EXAMPLE_COM_GOOD, ROOT1_INT1],
         stapled_ocsp: Some(include_bytes!("root1-int1-ee_example.com-good.ocsp")),
@@ -148,7 +143,7 @@ mock_root_test_cases! {
         expected_result: Ok(()),
         other_error: no_error!(),
     },
-    valid_stapled_good_ipv4 [ any(windows, target_os = "android", target_os = "macos", target_os = "linux") ] => TestCase {
+    valid_stapled_good_ipv4 [ any(windows, unix) ] => TestCase {
         reference_id: LOCALHOST_IPV4,
         chain: &[ROOT1_INT1_LOCALHOST_IPV4_GOOD, ROOT1_INT1],
         stapled_ocsp: Some(include_bytes!("root1-int1-ee_127.0.0.1-good.ocsp")),
@@ -156,7 +151,7 @@ mock_root_test_cases! {
         expected_result: Ok(()),
         other_error: no_error!(),
     },
-    valid_stapled_good_ipv6 [ any(windows, target_os = "android", target_os = "macos", target_os = "linux") ] => TestCase {
+    valid_stapled_good_ipv6 [ any(windows, unix) ] => TestCase {
         reference_id: LOCALHOST_IPV6,
         chain: &[ROOT1_INT1_LOCALHOST_IPV6_GOOD, ROOT1_INT1],
         stapled_ocsp: Some(include_bytes!("root1-int1-ee_1-good.ocsp")),
@@ -197,7 +192,7 @@ mock_root_test_cases! {
     // (AIA is an extension that allows downloading of missing data,
     // like missing certificates, during validation; see
     // https://datatracker.ietf.org/doc/html/rfc5280#section-5.2.7).
-    ee_only_dns [ any(windows, target_os = "android", target_os = "macos", target_os = "linux") ] => TestCase {
+    ee_only_dns [ any(windows, unix) ] => TestCase {
         reference_id: EXAMPLE_COM,
         chain: &[ROOT1_INT1_EXAMPLE_COM_GOOD],
         stapled_ocsp: None,
@@ -205,7 +200,7 @@ mock_root_test_cases! {
         expected_result: Err(TlsError::InvalidCertificate(CertificateError::UnknownIssuer)),
         other_error: no_error!(),
     },
-    ee_only_ipv4 [ any(windows, target_os = "android", target_os = "macos", target_os = "linux") ] => TestCase {
+    ee_only_ipv4 [ any(windows, unix) ] => TestCase {
         reference_id: LOCALHOST_IPV4,
         chain: &[ROOT1_INT1_LOCALHOST_IPV4_GOOD],
         stapled_ocsp: None,
@@ -213,7 +208,7 @@ mock_root_test_cases! {
         expected_result: Err(TlsError::InvalidCertificate(CertificateError::UnknownIssuer)),
         other_error: no_error!(),
     },
-    ee_only_ipv6 [ any(windows, target_os = "android", target_os = "macos", target_os = "linux") ] => TestCase {
+    ee_only_ipv6 [ any(windows, unix) ] => TestCase {
         reference_id: LOCALHOST_IPV6,
         chain: &[ROOT1_INT1_LOCALHOST_IPV6_GOOD],
         stapled_ocsp: None,
@@ -222,7 +217,7 @@ mock_root_test_cases! {
         other_error: no_error!(),
     },
     // Validation fails when the certificate isn't valid for the reference ID.
-    domain_mismatch_dns [ any(windows, target_os = "android", target_os = "macos", target_os = "linux") ] => TestCase {
+    domain_mismatch_dns [ any(windows, unix) ] => TestCase {
         reference_id: "example.org",
         chain: &[ROOT1_INT1_EXAMPLE_COM_GOOD, ROOT1_INT1],
         stapled_ocsp: None,
@@ -230,7 +225,7 @@ mock_root_test_cases! {
         expected_result: Err(TlsError::InvalidCertificate(CertificateError::NotValidForName)),
         other_error: no_error!(),
     },
-    domain_mismatch_ipv4 [ any(windows, target_os = "android", target_os = "macos", target_os = "linux") ] => TestCase {
+    domain_mismatch_ipv4 [ any(windows, unix) ] => TestCase {
         reference_id: "198.168.0.1",
         chain: &[ROOT1_INT1_LOCALHOST_IPV4_GOOD, ROOT1_INT1],
         stapled_ocsp: None,
@@ -238,7 +233,7 @@ mock_root_test_cases! {
         expected_result: Err(TlsError::InvalidCertificate(CertificateError::NotValidForName)),
         other_error: no_error!(),
     },
-    domain_mismatch_ipv6 [ any(windows, target_os = "android", target_os = "macos", target_os = "linux") ] => TestCase {
+    domain_mismatch_ipv6 [ any(windows, unix) ] => TestCase {
         reference_id: "::ffff:c6a8:1",
         chain: &[ROOT1_INT1_LOCALHOST_IPV6_GOOD, ROOT1_INT1],
         stapled_ocsp: None,
@@ -246,7 +241,7 @@ mock_root_test_cases! {
         expected_result: Err(TlsError::InvalidCertificate(CertificateError::NotValidForName)),
         other_error: no_error!(),
     },
-    wrong_eku_dns [ any(windows, target_os = "android", target_os = "macos", target_os = "linux") ] => TestCase {
+    wrong_eku_dns [ any(windows, unix) ] => TestCase {
         reference_id: EXAMPLE_COM,
         chain: &[include_bytes!("root1-int1-ee_example.com-wrong_eku.crt"), ROOT1_INT1],
         stapled_ocsp: None,
@@ -255,7 +250,7 @@ mock_root_test_cases! {
             CertificateError::Other(Arc::from(EkuError)))),
         other_error: Some(EkuError),
     },
-    wrong_eku_ipv4 [ any(windows, target_os = "android", target_os = "macos", target_os = "linux") ] => TestCase {
+    wrong_eku_ipv4 [ any(windows, unix) ] => TestCase {
         reference_id: LOCALHOST_IPV4,
         chain: &[include_bytes!("root1-int1-ee_127.0.0.1-wrong_eku.crt"), ROOT1_INT1],
         stapled_ocsp: None,
@@ -264,7 +259,7 @@ mock_root_test_cases! {
             CertificateError::Other(Arc::from(EkuError)))),
         other_error: Some(EkuError),
     },
-    wrong_eku_ipv6 [ any(windows, target_os = "android", target_os = "macos", target_os = "linux") ] => TestCase {
+    wrong_eku_ipv6 [ any(windows, unix) ] => TestCase {
         reference_id: LOCALHOST_IPV6,
         chain: &[include_bytes!("root1-int1-ee_1-wrong_eku.crt"), ROOT1_INT1],
         stapled_ocsp: None,

--- a/rustls-platform-verifier/src/verification/mod.rs
+++ b/rustls-platform-verifier/src/verification/mod.rs
@@ -1,7 +1,17 @@
-#[cfg(any(target_os = "linux", target_arch = "wasm32"))]
+#[cfg(all(
+    any(unix, target_arch = "wasm32"),
+    not(target_os = "android"),
+    not(target_os = "macos"),
+    not(target_os = "ios")
+))]
 mod others;
 
-#[cfg(any(target_os = "linux", target_arch = "wasm32"))]
+#[cfg(all(
+    any(unix, target_arch = "wasm32"),
+    not(target_os = "android"),
+    not(target_os = "macos"),
+    not(target_os = "ios")
+))]
 pub use others::Verifier;
 
 #[cfg(any(target_os = "macos", target_os = "ios"))]


### PR DESCRIPTION
This branch relaxes the cfg gates that previously were Linux specific to allow Unix generally. Care is taken to ensure we still handle MacOS/iOS/Android specially where required.

FreeBSD in CI seems to be unable to use openssl-probe to find the system CA bundle, so we also add a BSD-specific dev-dependency on webpki-roots and update the real world verification suite to conditionally use the `Verifier::new_with_extra_roots` constructor to provide extra CA certs from webpki-roots.

It might be possible to fix the FreeBSD runner so that openssl-probe works (e.g. by `curl`ing a CA bundle into a different location, or setting the `SSL_CERT_FILE` env var) but this approach has the benefit of adding coverage for `new_with_extra_roots`.

Since GitHub actions doesn't offer FreeBSD runners we follow the Quinn project's lead and use `vmactions/freebsd-vm@v1` to run a FreeBSD VM on the runner, and our tests within the VM.

Resolves https://github.com/rustls/rustls-platform-verifier/issues/53