### PR TITLE
Fix incorrect platform-specific Verifier documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ Users may wish to augment these certificates with [webpki-roots] using [`Verifie
 a system CA bundle is unavailable.
 
 [`ServerCertVerifierBuilder`]: https://docs.rs/rustls/latest/rustls/client/struct.ServerCertVerifierBuilder.html
+[`Verifier::new_with_extra_roots`]: https://docs.rs/rustls-platform-verifier/latest/rustls_platform_verifier/struct.Verifier.html#method.new_with_extra_roots
 [rustls-native-certs]: https://github.com/rustls/rustls-native-certs
 [openssl-probe]: https://github.com/alexcrichton/openssl-probe
 [webpki-roots]: https://github.com/rustls/webpki-roots

--- a/rustls-platform-verifier/src/lib.rs
+++ b/rustls-platform-verifier/src/lib.rs
@@ -1,4 +1,4 @@
-#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 #![doc = include_str!("../README.md")]
 #![warn(missing_docs)]
 
@@ -9,9 +9,10 @@ mod verification;
 pub use verification::Verifier;
 
 // Build the Android module when generating docs so that
-// the Android-specific functions are included.
-#[cfg_attr(docsrs, cfg(any(target_os = "android", doc)))]
-#[cfg_attr(not(docsrs), cfg(target_os = "android"))]
+// the Android-specific functions are included regardless of
+// the host.
+#[cfg(any(all(doc, docsrs), target_os = "android"))]
+#[cfg_attr(docsrs, doc(cfg(target_os = "android")))]
 pub mod android;
 
 #[cfg(windows)]


### PR DESCRIPTION
This PR fixes the incorrect documentation on docs.rs pointed out in #56. The root cause of the problem was that when I originally wrote the Android documentation parts, I used the `doc_auto_cfg` feature instead of the `doc_cfg` by mistake. The former is too eager and assumes that anything with a `#[cfg()]` gate is only available under the gated conditions.

Instead of trying to get what we want with `doc_auto_cfg`, and especially since we only have one item that needs special documentation treatment, I've instead switched to use `doc_cfg` "manually". This approach was partially inspired by [how Tokio generates](https://github.com/tokio-rs/tokio/blob/master/tokio/src/macros/cfg.rs#L18-L26) their platform-specific documentation.

Documentation generated from a Windows system:
![image](https://github.com/rustls/rustls-platform-verifier/assets/68570223/20c5da47-bbf2-498a-b185-3288643d7298)

Documentation generated on a macOS system:
<img width="1006" alt="image" src="https://github.com/rustls/rustls-platform-verifier/assets/68570223/5e2ca693-97e5-415a-8b08-26867cd5d425">


Finally, I fixed a broken doc warning in the README when referencing the `new_with_extra_roots` function. Since this function only exists on Linux right now, documentation built on Windows and macOS won't make that symbol available. I've chosen to link to docs.rs instead for that function at least until the other platforms gain that function too.

Closes #56 