### PR TITLE
backport BSD support for rel-0.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -162,6 +162,28 @@ jobs:
 
       # TODO: Test iOS in CI too.
 
+  test-freebsd:
+    name: Test (FreeBSD)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: test on freebsd
+        uses: vmactions/freebsd-vm@v1
+        # Settings adopted from https://github.com/quinn-rs/quinn
+        with:
+          usesh: true
+          mem: 4096
+          copyback: false
+          prepare: |
+            pkg install -y curl
+            curl https://sh.rustup.rs -sSf --output rustup.sh
+            sh rustup.sh -y --profile minimal --default-toolchain stable
+            echo "~~~~ rustc --version ~~~~"
+            $HOME/.cargo/bin/rustc --version
+            echo "~~~~ freebsd-version ~~~~"
+            freebsd-version
+          run: $HOME/.cargo/bin/cargo test
+
   fmt:
     name: Rustfmt
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ checking. If you require revocation checking on these platforms, prefer construc
 `WebPkiServerVerifier`, providing necessary CRLs. See the Rustls [`ServerCertVerifierBuilder`] docs for more
 information.
 
-[ServerCertVerifierBuilder]: https://docs.rs/rustls/latest/rustls/client/struct.ServerCertVerifierBuilder.html
+[`ServerCertVerifierBuilder`]: https://docs.rs/rustls/latest/rustls/client/struct.ServerCertVerifierBuilder.html
 
 ## Installation and setup
 On most platforms, no setup should be required beyond adding the dependency via `cargo`:

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ This library supports the following platforms and flows:
 | macOS (10.14+) | macOS platform roots and keychain certificate | macOS `Security.framework`           | Yes                |
 | iOS            | iOS platform roots and keychain certificates  | iOS `Security.framework`             | Yes                |
 | Android        | Android System Trust Store                    | Android Trust Manager                | Sometimes[^1]      |
-| Linux          | webpki roots and platform certificate bundles | webpki                               | No[^2]             |
+| Linux          | System CA bundle, or user-provided certs[^3]  | webpki                               | No[^2]             |
 | WASM           | webpki roots                                  | webpki                               | No[^2]             |
 
 [^1]: On Android, revocation checking requires API version >= 24 (e.g. at least Android 7.0, August 2016).
@@ -36,7 +36,14 @@ checking. If you require revocation checking on these platforms, prefer construc
 `WebPkiServerVerifier`, providing necessary CRLs. See the Rustls [`ServerCertVerifierBuilder`] docs for more
 information.
 
+[^3]: On Linux the [rustls-native-certs] and [openssl-probe] crates are used to try and discover the system CA bundle.
+Users may wish to augment these certificates with [webpki-roots] using [`Verifier::new_with_extra_roots`] in case
+a system CA bundle is unavailable.
+
 [`ServerCertVerifierBuilder`]: https://docs.rs/rustls/latest/rustls/client/struct.ServerCertVerifierBuilder.html
+[rustls-native-certs]: https://github.com/rustls/rustls-native-certs
+[openssl-probe]: https://github.com/alexcrichton/openssl-probe
+[webpki-roots]: https://github.com/rustls/webpki-roots
 
 ## Installation and setup
 On most platforms, no setup should be required beyond adding the dependency via `cargo`:

--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ Users may wish to augment these certificates with [webpki-roots] using [`Verifie
 a system CA bundle is unavailable.
 
 [`ServerCertVerifierBuilder`]: https://docs.rs/rustls/latest/rustls/client/struct.ServerCertVerifierBuilder.html
+[`Verifier::new_with_extra_roots`]: https://docs.rs/rustls-platform-verifier/latest/rustls_platform_verifier/struct.Verifier.html#method.new_with_extra_roots
 [rustls-native-certs]: https://github.com/rustls/rustls-native-certs
 [openssl-probe]: https://github.com/alexcrichton/openssl-probe
 [webpki-roots]: https://github.com/rustls/webpki-roots

--- a/rustls-platform-verifier/Cargo.toml
+++ b/rustls-platform-verifier/Cargo.toml
@@ -35,7 +35,7 @@ base64 = { version = "0.21", optional = true } # Only used when the `cert-loggin
 jni = { version = "0.19", default-features = false, optional = true } # Only used during doc generation
 once_cell = { version = "1.9", optional = true } # Only used during doc generation.
 
-[target.'cfg(target_os = "linux")'.dependencies]
+[target.'cfg(all(unix, not(target_os = "android"), not(target_os = "macos"), not(target_os = "ios")))'.dependencies]
 rustls-native-certs = "0.6"
 once_cell = "1.9"
 webpki = { package = "rustls-webpki", version = "0.101", features = ["alloc", "std"] }
@@ -49,6 +49,10 @@ android_logger = { version = "0.13", optional = true } # Only used during testin
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 once_cell = "1.9"
+webpki-roots = "0.25"
+
+# BSD targets require webpki-roots for the real-world verification tests.
+[target.'cfg(target_os = "freebsd")'.dev-dependencies]
 webpki-roots = "0.25"
 
 [target.'cfg(any(target_os = "macos", target_os = "ios"))'.dependencies]

--- a/rustls-platform-verifier/src/lib.rs
+++ b/rustls-platform-verifier/src/lib.rs
@@ -1,4 +1,4 @@
-#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 #![doc = include_str!("../README.md")]
 #![warn(missing_docs)]
 
@@ -9,9 +9,10 @@ mod verification;
 pub use verification::Verifier;
 
 // Build the Android module when generating docs so that
-// the Android-specific functions are included.
-#[cfg_attr(docsrs, cfg(any(target_os = "android", doc)))]
-#[cfg_attr(not(docsrs), cfg(target_os = "android"))]
+// the Android-specific functions are included regardless of
+// the host.
+#[cfg(any(all(doc, docsrs), target_os = "android"))]
+#[cfg_attr(docsrs, doc(cfg(target_os = "android")))]
 pub mod android;
 
 #[cfg(windows)]

--- a/rustls-platform-verifier/src/tests/verification_mock/mod.rs
+++ b/rustls-platform-verifier/src/tests/verification_mock/mod.rs
@@ -13,12 +13,7 @@
 //! any parts of the system outside of these tests. See the `#![cfg(...)]`
 //! immediately below to see which platforms run these tests.
 
-#![cfg(any(
-    windows,
-    target_os = "android",
-    target_os = "macos",
-    target_os = "linux"
-))]
+#![cfg(all(any(windows, unix, target_os = "android"), not(target_os = "ios")))]
 
 use super::TestCase;
 use crate::tests::assert_cert_error_eq;
@@ -116,42 +111,42 @@ fn test_verification_without_mock_root() {
 // Verifies that our test trust anchor(s) are not trusted when `Verifier::new()`
 // is used.
 mock_root_test_cases! {
-    valid_no_stapling_dns [ any(windows, target_os = "android", target_os = "macos", target_os = "linux") ] => TestCase {
+    valid_no_stapling_dns [ any(windows, unix) ] => TestCase {
         reference_id: EXAMPLE_COM,
         chain: &[ROOT1_INT1_EXAMPLE_COM_GOOD, ROOT1_INT1],
         stapled_ocsp: None,
         expected_result: Ok(()),
         other_error: no_error!(),
     },
-    valid_no_stapling_ipv4 [ any(windows, target_os = "android", target_os = "macos", target_os = "linux") ] => TestCase {
+    valid_no_stapling_ipv4 [ any(windows, unix) ] => TestCase {
         reference_id: LOCALHOST_IPV4,
         chain: &[ROOT1_INT1_LOCALHOST_IPV4_GOOD, ROOT1_INT1],
         stapled_ocsp: None,
         expected_result: Ok(()),
         other_error: no_error!(),
     },
-    valid_no_stapling_ipv6 [ any(windows, target_os = "android", target_os = "macos", target_os = "linux") ] => TestCase {
+    valid_no_stapling_ipv6 [ any(windows, unix) ] => TestCase {
         reference_id: LOCALHOST_IPV6,
         chain: &[ROOT1_INT1_LOCALHOST_IPV6_GOOD, ROOT1_INT1],
         stapled_ocsp: None,
         expected_result: Ok(()),
         other_error: no_error!(),
     },
-    valid_stapled_good_dns [ any(windows, target_os = "android", target_os = "android", target_os = "macos", target_os = "linux") ] => TestCase {
+    valid_stapled_good_dns [ any(windows, unix) ] => TestCase {
         reference_id: EXAMPLE_COM,
         chain: &[ROOT1_INT1_EXAMPLE_COM_GOOD, ROOT1_INT1],
         stapled_ocsp: Some(include_bytes!("root1-int1-ee_example.com-good.ocsp")),
         expected_result: Ok(()),
         other_error: no_error!(),
     },
-    valid_stapled_good_ipv4 [ any(windows, target_os = "android", target_os = "macos", target_os = "linux") ] => TestCase {
+    valid_stapled_good_ipv4 [ any(windows, unix) ] => TestCase {
         reference_id: LOCALHOST_IPV4,
         chain: &[ROOT1_INT1_LOCALHOST_IPV4_GOOD, ROOT1_INT1],
         stapled_ocsp: Some(include_bytes!("root1-int1-ee_127.0.0.1-good.ocsp")),
         expected_result: Ok(()),
         other_error: no_error!(),
     },
-    valid_stapled_good_ipv6 [ any(windows, target_os = "android", target_os = "macos", target_os = "linux") ] => TestCase {
+    valid_stapled_good_ipv6 [ any(windows, unix) ] => TestCase {
         reference_id: LOCALHOST_IPV6,
         chain: &[ROOT1_INT1_LOCALHOST_IPV6_GOOD, ROOT1_INT1],
         stapled_ocsp: Some(include_bytes!("root1-int1-ee_1-good.ocsp")),
@@ -188,21 +183,21 @@ mock_root_test_cases! {
     // (AIA is an extension that allows downloading of missing data,
     // like missing certificates, during validation; see
     // https://datatracker.ietf.org/doc/html/rfc5280#section-5.2.7).
-    ee_only_dns [ any(windows, target_os = "android", target_os = "macos", target_os = "linux") ] => TestCase {
+    ee_only_dns [ any(windows, unix) ] => TestCase {
         reference_id: EXAMPLE_COM,
         chain: &[ROOT1_INT1_EXAMPLE_COM_GOOD],
         stapled_ocsp: None,
         expected_result: Err(TlsError::InvalidCertificate(CertificateError::UnknownIssuer)),
         other_error: no_error!(),
     },
-    ee_only_ipv4 [ any(windows, target_os = "android", target_os = "macos", target_os = "linux") ] => TestCase {
+    ee_only_ipv4 [ any(windows, unix) ] => TestCase {
         reference_id: LOCALHOST_IPV4,
         chain: &[ROOT1_INT1_LOCALHOST_IPV4_GOOD],
         stapled_ocsp: None,
         expected_result: Err(TlsError::InvalidCertificate(CertificateError::UnknownIssuer)),
         other_error: no_error!(),
     },
-    ee_only_ipv6 [ any(windows, target_os = "android", target_os = "macos", target_os = "linux") ] => TestCase {
+    ee_only_ipv6 [ any(windows, unix) ] => TestCase {
         reference_id: LOCALHOST_IPV6,
         chain: &[ROOT1_INT1_LOCALHOST_IPV6_GOOD],
         stapled_ocsp: None,
@@ -210,28 +205,28 @@ mock_root_test_cases! {
         other_error: no_error!(),
     },
     // Validation fails when the certificate isn't valid for the reference ID.
-    domain_mismatch_dns [ any(windows, target_os = "android", target_os = "macos", target_os = "linux") ] => TestCase {
+    domain_mismatch_dns [ any(windows, unix) ] => TestCase {
         reference_id: "example.org",
         chain: &[ROOT1_INT1_EXAMPLE_COM_GOOD, ROOT1_INT1],
         stapled_ocsp: None,
         expected_result: Err(TlsError::InvalidCertificate(CertificateError::NotValidForName)),
         other_error: no_error!(),
     },
-    domain_mismatch_ipv4 [ any(windows, target_os = "android", target_os = "macos", target_os = "linux") ] => TestCase {
+    domain_mismatch_ipv4 [ any(windows, unix) ] => TestCase {
         reference_id: "198.168.0.1",
         chain: &[ROOT1_INT1_LOCALHOST_IPV4_GOOD, ROOT1_INT1],
         stapled_ocsp: None,
         expected_result: Err(TlsError::InvalidCertificate(CertificateError::NotValidForName)),
         other_error: no_error!(),
     },
-    domain_mismatch_ipv6 [ any(windows, target_os = "android", target_os = "macos", target_os = "linux") ] => TestCase {
+    domain_mismatch_ipv6 [ any(windows, unix) ] => TestCase {
         reference_id: "::ffff:c6a8:1",
         chain: &[ROOT1_INT1_LOCALHOST_IPV6_GOOD, ROOT1_INT1],
         stapled_ocsp: None,
         expected_result: Err(TlsError::InvalidCertificate(CertificateError::NotValidForName)),
         other_error: no_error!(),
     },
-    wrong_eku_dns [ any(windows, target_os = "android", target_os = "macos", target_os = "linux") ] => TestCase {
+    wrong_eku_dns [ any(windows, unix) ] => TestCase {
         reference_id: EXAMPLE_COM,
         chain: &[include_bytes!("root1-int1-ee_example.com-wrong_eku.crt"), ROOT1_INT1],
         stapled_ocsp: None,
@@ -239,7 +234,7 @@ mock_root_test_cases! {
             CertificateError::Other(Arc::from(EkuError)))),
         other_error: Some(EkuError),
     },
-    wrong_eku_ipv4 [ any(windows, target_os = "android", target_os = "macos", target_os = "linux") ] => TestCase {
+    wrong_eku_ipv4 [ any(windows, unix) ] => TestCase {
         reference_id: LOCALHOST_IPV4,
         chain: &[include_bytes!("root1-int1-ee_127.0.0.1-wrong_eku.crt"), ROOT1_INT1],
         stapled_ocsp: None,
@@ -247,7 +242,7 @@ mock_root_test_cases! {
             CertificateError::Other(Arc::from(EkuError)))),
         other_error: Some(EkuError),
     },
-    wrong_eku_ipv6 [ any(windows, target_os = "android", target_os = "macos", target_os = "linux") ] => TestCase {
+    wrong_eku_ipv6 [ any(windows, unix) ] => TestCase {
         reference_id: LOCALHOST_IPV6,
         chain: &[include_bytes!("root1-int1-ee_1-wrong_eku.crt"), ROOT1_INT1],
         stapled_ocsp: None,

--- a/rustls-platform-verifier/src/tests/verification_real_world/mod.rs
+++ b/rustls-platform-verifier/src/tests/verification_real_world/mod.rs
@@ -124,6 +124,23 @@ macro_rules! no_error {
 fn real_world_test<E: std::error::Error>(test_case: &TestCase<E>) {
     log::info!("verifying {:?}", test_case.expected_result);
 
+    // On BSD systems openssl-probe fails to find the system CA bundle,
+    // so we must provide extra roots from webpki-roots.
+    #[cfg(target_os = "freebsd")]
+    let verifier = Verifier::new_with_extra_roots(
+        webpki_roots::TLS_SERVER_ROOTS
+            .iter()
+            .map(|ta| {
+                rustls::OwnedTrustAnchor::from_subject_spki_name_constraints(
+                    ta.subject,
+                    ta.spki,
+                    ta.name_constraints,
+                )
+            })
+            .collect::<Vec<_>>(),
+    );
+
+    #[cfg(not(target_os = "freebsd"))]
     let verifier = Verifier::new();
 
     let mut chain = test_case

--- a/rustls-platform-verifier/src/verification/mod.rs
+++ b/rustls-platform-verifier/src/verification/mod.rs
@@ -1,7 +1,17 @@
-#[cfg(any(target_os = "linux", target_arch = "wasm32"))]
+#[cfg(all(
+    any(unix, target_arch = "wasm32"),
+    not(target_os = "android"),
+    not(target_os = "macos"),
+    not(target_os = "ios")
+))]
 mod others;
 
-#[cfg(any(target_os = "linux", target_arch = "wasm32"))]
+#[cfg(all(
+    any(unix, target_arch = "wasm32"),
+    not(target_os = "android"),
+    not(target_os = "macos"),
+    not(target_os = "ios")
+))]
 pub use others::Verifier;
 
 #[cfg(any(target_os = "macos", target_os = "ios"))]


### PR DESCRIPTION
This branch backports a few changes from `main` targetting the `rel-0.1` branch. This will unblock preparing a 0.1.1 release that adds BSD support.

* https://github.com/rustls/rustls-platform-verifier/pull/55 - BSD support
* https://github.com/rustls/rustls-platform-verifier/pull/57 - doc fixes
* https://github.com/rustls/rustls-platform-verifier/pull/54 - doc fixes