### PR TITLE
0.2.0 release preparation

### DIFF
--- a/rustls-platform-verifier/Cargo.toml
+++ b/rustls-platform-verifier/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rustls-platform-verifier"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["ComplexSpaces <complexspacescode@gmail.com>", "1Password"]
 description = "rustls-platform-verifier supports verifying TLS certificates in rustls with the operating system verifier"
 keywords = ["tls", "certificate", "verification", "os", "native"]


### PR DESCRIPTION
Proposed initial CHANGELOG entry:
- Rustls version updated from 0.21 to 0.22

These are the steps remaining for the release after this merges:
- [x] Generate the Android Maven artifacts (N/A - no `android/` changes)
- [ ] Create rel-0.2 branch
- [ ] Create Git tag
- [ ] Push tag
- [ ] `cargo publish` (`--allow-dirty` may be needed based on the above)
- [ ] Create companion GitHub release