### PR TITLE
upgrade jni v0.21

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -118,16 +118,18 @@ dependencies = [
 
 [[package]]
 name = "jni"
-version = "0.19.0"
+version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6df18c2e3db7e453d3c6ac5b3e9d5182664d28788126d39b91f2d1e22b017ec"
+checksum = "1a87aa2bb7d2af34197c04845522473242e1aa17c12f4935d5856491a7fb8c97"
 dependencies = [
  "cesu8",
+ "cfg-if",
  "combine",
  "jni-sys",
  "log",
  "thiserror",
  "walkdir",
+ "windows-sys 0.45.0",
 ]
 
 [[package]]
@@ -350,7 +352,7 @@ version = "0.1.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c3733bf4cf7ea0880754e19cb5a462007c4a8c1914bff372ccc95b464f1df88"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -549,11 +551,35 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-sys"
+version = "0.45.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
+dependencies = [
+ "windows-targets 0.42.2",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.48.5",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e5180c00cd44c9b1c88adb3693291f1cd93605ded80c250a75d472756b4d071"
+dependencies = [
+ "windows_aarch64_gnullvm 0.42.2",
+ "windows_aarch64_msvc 0.42.2",
+ "windows_i686_gnu 0.42.2",
+ "windows_i686_msvc 0.42.2",
+ "windows_x86_64_gnu 0.42.2",
+ "windows_x86_64_gnullvm 0.42.2",
+ "windows_x86_64_msvc 0.42.2",
 ]
 
 [[package]]
@@ -562,14 +588,20 @@ version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
 dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
+ "windows_aarch64_gnullvm 0.48.5",
+ "windows_aarch64_msvc 0.48.5",
+ "windows_i686_gnu 0.48.5",
+ "windows_i686_msvc 0.48.5",
+ "windows_x86_64_gnu 0.48.5",
+ "windows_x86_64_gnullvm 0.48.5",
+ "windows_x86_64_msvc 0.48.5",
 ]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
@@ -579,9 +611,21 @@ checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
 
 [[package]]
 name = "windows_aarch64_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
+
+[[package]]
+name = "windows_aarch64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -591,9 +635,21 @@ checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
+
+[[package]]
+name = "windows_i686_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -603,9 +659,21 @@ checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
 
 [[package]]
 name = "windows_x86_64_msvc"

--- a/rustls-platform-verifier/Cargo.toml
+++ b/rustls-platform-verifier/Cargo.toml
@@ -32,7 +32,7 @@ docsrs = ["jni", "once_cell"]
 rustls = { version = "0.21", features = ["dangerous_configuration", "tls12", "logging"] }
 log = { version = "0.4" }
 base64 = { version = "0.21", optional = true } # Only used when the `cert-logging` feature is enabled.
-jni = { version = "0.19", default-features = false, optional = true } # Only used during doc generation
+jni = { version = "0.21", default-features = false, optional = true } # Only used during doc generation
 once_cell = { version = "1.9", optional = true } # Only used during doc generation.
 
 [target.'cfg(all(unix, not(target_os = "android"), not(target_os = "macos"), not(target_os = "ios")))'.dependencies]
@@ -42,7 +42,7 @@ webpki = { package = "rustls-webpki", version = "0.101", features = ["alloc", "s
 
 [target.'cfg(target_os = "android")'.dependencies]
 rustls-platform-verifier-android = { path = "../android-release-support", version = "0.1.0" }
-jni = { version = "0.19", default-features = false }
+jni = { version = "0.21", default-features = false }
 webpki = { package = "rustls-webpki", version = "0.101", features = ["alloc", "std"] }
 once_cell = "1.9"
 android_logger = { version = "0.13", optional = true } # Only used during testing.

--- a/rustls-platform-verifier/src/android.rs
+++ b/rustls-platform-verifier/src/android.rs
@@ -167,6 +167,7 @@ impl<'a> Context<'a> {
 pub(super) fn with_context<F, T>(f: F) -> Result<T, Error>
 where
     F: FnOnce(&mut Context) -> Result<T, Error>,
+    T: 'static,
 {
     let mut context = global().context()?;
 
@@ -175,6 +176,7 @@ where
 
     let res = f(&mut context);
 
+    // Safety: no local references remained, minicking `jni::JNIEnv::with_local_frame`
     unsafe { context.env.pop_local_frame(&JObject::null()) }?;
 
     res

--- a/rustls-platform-verifier/src/tests/ffi.rs
+++ b/rustls-platform-verifier/src/tests/ffi.rs
@@ -29,7 +29,7 @@ mod android {
     const SUCCESS_MARKER: &str = "success";
 
     fn run_android_test<'a>(
-        env: &'a JNIEnv,
+        env: &'a mut JNIEnv,
         cx: JObject,
         suite_name: &'static str,
         test_cases: &'static [fn()],
@@ -46,7 +46,7 @@ mod android {
                     .with_max_level(log::Level::Trace.to_level_filter())
                     .with_filter(log_filter),
             );
-            crate::android::init_hosted(env, cx).unwrap();
+            crate::android::init_hosted(env, &cx).unwrap();
             std::panic::set_hook(Box::new(|info| {
                 let msg = if let Some(msg) = info.payload().downcast_ref::<&'static str>() {
                     msg
@@ -85,53 +85,53 @@ mod android {
 
     #[export_name = "Java_org_rustls_platformverifier_CertificateVerifierTests_mockTests"]
     pub extern "C" fn rustls_platform_verifier_mock_test_suite(
-        env: JNIEnv,
+        mut env: JNIEnv,
         _class: JClass,
         cx: JObject,
     ) -> jstring {
         log::info!("running mock test suite...");
 
         run_android_test(
-            &env,
+            &mut env,
             cx,
             "mock tests",
             tests::verification_mock::ALL_TEST_CASES,
         )
-        .into_inner()
+        .into_raw()
     }
 
     #[export_name = "Java_org_rustls_platformverifier_CertificateVerifierTests_verifyMockRootUsage"]
     pub extern "C" fn rustls_platform_verifier_verify_mock_root_usage(
-        env: JNIEnv,
+        mut env: JNIEnv,
         _class: JClass,
         cx: JObject,
     ) -> jstring {
         log::info!("verifying mock roots are not used by default...");
 
         run_android_test(
-            &env,
+            &mut env,
             cx,
             "mock root verification",
             &[tests::verification_mock::verification_without_mock_root],
         )
-        .into_inner()
+        .into_raw()
     }
 
     #[export_name = "Java_org_rustls_platformverifier_CertificateVerifierTests_realWorldTests"]
     pub extern "C" fn rustls_platform_verifier_real_world_test_suite(
-        env: JNIEnv,
+        mut env: JNIEnv,
         _class: JClass,
         cx: JObject,
     ) -> jstring {
         log::info!("running real world suite...");
 
         run_android_test(
-            &env,
+            &mut env,
             cx,
             "real world",
             tests::verification_real_world::ALL_TEST_CASES,
         )
-        .into_inner()
+        .into_raw()
     }
 }
 

--- a/rustls-platform-verifier/src/verification/android.rs
+++ b/rustls-platform-verifier/src/verification/android.rs
@@ -150,7 +150,7 @@ impl Verifier {
                         cert_verifier_class,
                         "addMockRoot",
                         "([B)V",
-                        &[JValue::from(mock_root)],
+                        &[JValue::from(&mock_root)],
                     )?
                     .v()
                     .expect("failed to add test root")

--- a/rustls-platform-verifier/src/verification/android.rs
+++ b/rustls-platform-verifier/src/verification/android.rs
@@ -232,7 +232,10 @@ impl Verifier {
     }
 }
 
-fn extract_result_info(env: &mut JNIEnv<'_>, result: &JObject<'_>) -> (VerifierStatus, Option<String>) {
+fn extract_result_info(
+    env: &mut JNIEnv<'_>,
+    result: &JObject<'_>,
+) -> (VerifierStatus, Option<String>) {
     let status_code = env
         .get_field(result, "code", "I")
         .and_then(|code| code.i())
@@ -253,10 +256,12 @@ fn extract_result_info(env: &mut JNIEnv<'_>, result: &JObject<'_>) -> (VerifierS
     let msg = env
         .get_field(result, "message", "Ljava/lang/String;")
         .and_then(|m| m.l())
-        .map(|s| if s.is_null() {
-            None
-        } else {
-            JavaStr::from_env(env, &s.into()).ok().map(String::from)
+        .map(|s| {
+            if s.is_null() {
+                None
+            } else {
+                JavaStr::from_env(env, &s.into()).ok().map(String::from)
+            }
         })
         .unwrap();
 


### PR DESCRIPTION
~jni v0.19 doesn't work for me.~

~I use tokio multi threads runtime, and our app is killed by system -~

```
e.android.debug: java_vm_ext.cc:594] JNI DETECTED ERROR IN APPLICATION: a thread (tid 5917 is making JNI calls without being attached
e.android.debug: java_vm_ext.cc:594]     in call to PushLocalFrame
```
~It turns out `java_vm::get_env()` goes null even after calling `AttachCurrentThread` in a few threads, while other threads are okay.~
~I have no idea. However, upgrade to jni v0.21.0 eliminates the problem for me.~

fixes #22 