### PR TITLE
Prepare for 0.1.1 release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -302,7 +302,7 @@ dependencies = [
 
 [[package]]
 name = "rustls-platform-verifier"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "android_logger",
  "base64",

--- a/rustls-platform-verifier/Cargo.toml
+++ b/rustls-platform-verifier/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rustls-platform-verifier"
-version = "0.1.0"
+version = "0.1.1"
 authors = ["ComplexSpaces <complexspacescode@gmail.com>", "1Password"]
 description = "rustls-platform-verifier supports verifying TLS certificates in rustls with the operating system verifier"
 keywords = ["tls", "certificate", "verification", "os", "native"]


### PR DESCRIPTION
This proposes a few 0.1 channel release, specifically `0.1.1`. It contains the following backports after 65b2a97aff062585d91c97ae3b7b1d17fbcd7b62:
- Fixing documentation to not have platform-specific rendering everywhere
- Clarifying UNIX root stores in the documentation/README
- Support for FreeBSD

### Post-merge steps

- [x] Generate Android Maven artifacts locally (N/A - no `android/` changes)
- [ ] Create and push Git tag
- [ ] `cargo publish` for each required crate, based on release steps
- [ ] Create companion GitHub release