### PR TITLE
Update rustls to 0.23

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -203,18 +203,18 @@ checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.66"
+version = "1.0.78"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18fb31db3f9bddb2ea821cde30a9f70117e3f119938b5ee630b7403aa6e2ead9"
+checksum = "e2422ad645d89c99f8f3e6b88a9fdeca7fabeac836b1002371c4367c8f984aae"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.33"
+version = "1.0.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5267fca4496028628a95160fc423a33e8b2e6af8a5302579e322e4b520293cae"
+checksum = "291ec9ab5efd934aaf503a6466c5d5251535d108ee747472c3977cc5acc868ef"
 dependencies = [
  "proc-macro2",
 ]
@@ -264,11 +264,11 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.22.1"
+version = "0.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe6b63262c9fcac8659abfaa96cac103d28166d3ff3eaf8f412e19f3ae9e5a48"
+checksum = "e153fc89608e0515660ca656fd7f2fa05ca6690f3fd6ad1b0a46e24a8130d838"
 dependencies = [
- "log",
+ "once_cell",
  "ring",
  "rustls-pki-types",
  "rustls-webpki",
@@ -301,9 +301,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.1.0"
+version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e9d979b3ce68192e42760c7810125eb6cf2ea10efae545a156063e61f314e2a"
+checksum = "5ede67b28608b4c60685c7d54122d4400d90f62b40caee7700e700380a390fa8"
 
 [[package]]
 name = "rustls-platform-verifier"
@@ -332,9 +332,9 @@ version = "0.1.0"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.102.0"
+version = "0.102.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de2635c8bc2b88d367767c5de8ea1d8db9af3f6219eba28442242d9ab81d1b89"
+checksum = "faaa0a62740bedb9b2ef5afa303da42764c012f743917351dc9a237ea1663610"
 dependencies = [
  "ring",
  "rustls-pki-types",
@@ -397,9 +397,9 @@ checksum = "81cdd64d312baedb58e21336b31bc043b77e01cc99033ce76ef539f78e965ebc"
 
 [[package]]
 name = "syn"
-version = "2.0.29"
+version = "2.0.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c324c494eba9d92503e6f1ef2e6df781e78f6a7705a0202d9801b198807d518a"
+checksum = "b699d15b36d1f02c3e7c69f8ffef53de37aefae075d8488d4ba1a7788d574a07"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/rustls-platform-verifier/Cargo.toml
+++ b/rustls-platform-verifier/Cargo.toml
@@ -26,29 +26,26 @@ dbg = []
 # by the platform's verifier.
 cert-logging = ["base64"]
 # Used for nicely documenting the Android-specific APIs. This feature is not stable.
-docsrs = ["jni", "once_cell"]
+docsrs = ["jni"]
 
 [dependencies]
 rustls = { version = "0.23", default-features = false, features = ["std"] }
 log = { version = "0.4" }
 base64 = { version = "0.21", optional = true } # Only used when the `cert-logging` feature is enabled.
 jni = { version = "0.19", default-features = false, optional = true } # Only used during doc generation
-once_cell = { version = "1.9", optional = true } # Only used during doc generation.
+once_cell = "1.9"
 
 [target.'cfg(all(unix, not(target_os = "android"), not(target_os = "macos"), not(target_os = "ios")))'.dependencies]
 rustls-native-certs = "0.7"
-once_cell = "1.9"
 webpki = { package = "rustls-webpki", version = "0.102", features = ["ring", "alloc", "std"] }
 
 [target.'cfg(target_os = "android")'.dependencies]
 rustls-platform-verifier-android = { path = "../android-release-support", version = "0.1.0" }
 jni = { version = "0.19", default-features = false }
 webpki = { package = "rustls-webpki", version = "0.102", features = ["ring", "alloc", "std"] }
-once_cell = "1.9"
 android_logger = { version = "0.13", optional = true } # Only used during testing.
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
-once_cell = "1.9"
 webpki-roots = "0.26"
 
 # BSD targets require webpki-roots for the real-world verification tests.

--- a/rustls-platform-verifier/Cargo.toml
+++ b/rustls-platform-verifier/Cargo.toml
@@ -29,7 +29,7 @@ cert-logging = ["base64"]
 docsrs = ["jni", "once_cell"]
 
 [dependencies]
-rustls = { version = "0.22.1", features = ["tls12", "logging"] }
+rustls = { version = "0.23", default-features = false, features = ["std", "ring"] }
 log = { version = "0.4" }
 base64 = { version = "0.21", optional = true } # Only used when the `cert-logging` feature is enabled.
 jni = { version = "0.19", default-features = false, optional = true } # Only used during doc generation

--- a/rustls-platform-verifier/Cargo.toml
+++ b/rustls-platform-verifier/Cargo.toml
@@ -19,7 +19,7 @@ crate-type = ["cdylib", "rlib"]
 # Enables a C interface to use for testing where `cargo` can't be used.
 # This feature is not stable, nor is the interface exported when it is enabled.
 # Do not rely on this or use it in production.
-ffi-testing = ["android_logger"]
+ffi-testing = ["android_logger", "rustls/ring"]
 # Enables APIs that expose lower-level verifier types for debugging purposes.
 dbg = []
 # Enables `log::debug` base64-encoded logging of all end-entity certificates processed
@@ -29,7 +29,7 @@ cert-logging = ["base64"]
 docsrs = ["jni", "once_cell"]
 
 [dependencies]
-rustls = { version = "0.23", default-features = false, features = ["std", "ring"] }
+rustls = { version = "0.23", default-features = false, features = ["std"] }
 log = { version = "0.4" }
 base64 = { version = "0.21", optional = true } # Only used when the `cert-logging` feature is enabled.
 jni = { version = "0.19", default-features = false, optional = true } # Only used during doc generation
@@ -63,6 +63,9 @@ security-framework-sys = { version = "2.4", features = ["OSX_10_14"] }
 
 [target.'cfg(windows)'.dependencies]
 winapi = { version = "0.3", features = ["wincrypt", "winerror"] }
+
+[dev-dependencies]
+rustls = { version = "0.23", default-features = false, features = ["ring"] }
 
 [package.metadata.docs.rs]
 rustdoc-args = ["--cfg", "docsrs"]

--- a/rustls-platform-verifier/src/tests/ffi.rs
+++ b/rustls-platform-verifier/src/tests/ffi.rs
@@ -47,6 +47,7 @@ mod android {
                     .with_filter(log_filter),
             );
             crate::android::init_hosted(env, cx).unwrap();
+            crate::tests::ensure_global_state();
             std::panic::set_hook(Box::new(|info| {
                 let msg = if let Some(msg) = info.payload().downcast_ref::<&'static str>() {
                     msg

--- a/rustls-platform-verifier/src/tests/mod.rs
+++ b/rustls-platform-verifier/src/tests/mod.rs
@@ -61,3 +61,7 @@ pub(crate) fn verification_time() -> pki_types::UnixTime {
     // Monday, March 11, 2024 8:30:25 PM UTC
     pki_types::UnixTime::since_unix_epoch(Duration::from_secs(1_710_189_025))
 }
+
+fn ensure_global_state() {
+    let _ = rustls::crypto::ring::default_provider().install_default();
+}

--- a/rustls-platform-verifier/src/tests/verification_mock/mod.rs
+++ b/rustls-platform-verifier/src/tests/verification_mock/mod.rs
@@ -16,7 +16,7 @@
 #![cfg(all(any(windows, unix, target_os = "android"), not(target_os = "ios")))]
 
 use super::TestCase;
-use crate::tests::{assert_cert_error_eq, verification_time};
+use crate::tests::{assert_cert_error_eq, ensure_global_state, verification_time};
 use crate::verification::{EkuError, Verifier};
 use rustls::client::danger::ServerCertVerifier;
 use rustls::pki_types;
@@ -79,6 +79,7 @@ const LOCALHOST_IPV6: &str = "::1";
 #[cfg(any(test, feature = "ffi-testing"))]
 #[cfg_attr(feature = "ffi-testing", allow(dead_code))]
 pub(super) fn verification_without_mock_root() {
+    ensure_global_state();
     // Since Rustls 0.22 constructing a webpki verifier (like the one backing Verifier on unix
     // systems) without any roots produces `OtherError(NoRootAnchors)` - since our FreeBSD CI
     // runner fails to find any roots with openssl-probe we need to provide webpki-roots here
@@ -283,6 +284,7 @@ mock_root_test_cases! {
 }
 
 fn test_with_mock_root<E: std::error::Error + PartialEq + 'static>(test_case: &TestCase<E>) {
+    ensure_global_state();
     log::info!("verifying {:?}", test_case.expected_result);
 
     let verifier = Verifier::new_with_fake_root(ROOT1); // TODO: time

--- a/rustls-platform-verifier/src/tests/verification_real_world/mod.rs
+++ b/rustls-platform-verifier/src/tests/verification_real_world/mod.rs
@@ -35,7 +35,7 @@
 //! Thus we don't expect these tests to be flaky w.r.t. that, except for
 //! potentially poor performance.     
 use super::TestCase;
-use crate::tests::{assert_cert_error_eq, verification_time};
+use crate::tests::{assert_cert_error_eq, ensure_global_state, verification_time};
 use crate::Verifier;
 use rustls::client::danger::ServerCertVerifier;
 use rustls::pki_types;
@@ -118,6 +118,7 @@ macro_rules! no_error {
 }
 
 fn real_world_test<E: std::error::Error>(test_case: &TestCase<E>) {
+    ensure_global_state();
     log::info!(
         "verifying ref ID {:?} expected {:?}",
         test_case.reference_id,

--- a/rustls-platform-verifier/src/verification/android.rs
+++ b/rustls-platform-verifier/src/verification/android.rs
@@ -1,3 +1,5 @@
+use std::sync::Arc;
+
 use jni::{
     objects::{JObject, JValue},
     strings::JavaStr,
@@ -44,7 +46,7 @@ pub struct Verifier {
     /// Testing only: The root CA certificate to trust.
     #[cfg(any(test, feature = "ffi-testing"))]
     test_only_root_ca_override: Option<Vec<u8>>,
-    default_provider: CryptoProvider,
+    default_provider: Arc<CryptoProvider>,
 }
 
 impl Default for Verifier {
@@ -73,7 +75,9 @@ impl Verifier {
         Self {
             #[cfg(any(test, feature = "ffi-testing"))]
             test_only_root_ca_override: None,
-            default_provider: rustls::crypto::ring::default_provider(),
+            default_provider: rustls::crypto::CryptoProvider::get_default()
+                .expect("rustls default CryptoProvider not set")
+                .clone(),
         }
     }
 
@@ -82,7 +86,9 @@ impl Verifier {
     pub(crate) fn new_with_fake_root(root: &[u8]) -> Self {
         Self {
             test_only_root_ca_override: Some(root.into()),
-            default_provider: rustls::crypto::ring::default_provider(),
+            default_provider: rustls::crypto::CryptoProvider::get_default()
+                .expect("rustls default CryptoProvider not set")
+                .clone(),
         }
     }
 

--- a/rustls-platform-verifier/src/verification/android.rs
+++ b/rustls-platform-verifier/src/verification/android.rs
@@ -5,6 +5,7 @@ use jni::{
     strings::JavaStr,
     JNIEnv,
 };
+use once_cell::sync::OnceCell;
 use rustls::client::danger::{HandshakeSignatureValid, ServerCertVerifier};
 use rustls::crypto::{verify_tls12_signature, verify_tls13_signature, CryptoProvider};
 use rustls::pki_types;
@@ -46,7 +47,7 @@ pub struct Verifier {
     /// Testing only: The root CA certificate to trust.
     #[cfg(any(test, feature = "ffi-testing"))]
     test_only_root_ca_override: Option<Vec<u8>>,
-    default_provider: Arc<CryptoProvider>,
+    default_provider: OnceCell<Arc<CryptoProvider>>,
 }
 
 impl Default for Verifier {
@@ -70,14 +71,13 @@ impl Drop for Verifier {
 
 impl Verifier {
     /// Creates a new instance of a TLS certificate verifier that utilizes the
-    /// Android certificate facilities
+    /// Android certificate facilities. The rustls default [`CryptoProvider`]
+    /// must be set before the verifier can be used.
     pub fn new() -> Self {
         Self {
             #[cfg(any(test, feature = "ffi-testing"))]
             test_only_root_ca_override: None,
-            default_provider: rustls::crypto::CryptoProvider::get_default()
-                .expect("rustls default CryptoProvider not set")
-                .clone(),
+            default_provider: OnceCell::new(),
         }
     }
 
@@ -86,10 +86,18 @@ impl Verifier {
     pub(crate) fn new_with_fake_root(root: &[u8]) -> Self {
         Self {
             test_only_root_ca_override: Some(root.into()),
-            default_provider: rustls::crypto::CryptoProvider::get_default()
-                .expect("rustls default CryptoProvider not set")
-                .clone(),
+            default_provider: OnceCell::new(),
         }
+    }
+
+    fn get_provider(&self) -> &CryptoProvider {
+        self.default_provider
+            .get_or_init(|| {
+                rustls::crypto::CryptoProvider::get_default()
+                    .expect("rustls default CryptoProvider not set")
+                    .clone()
+            })
+            .as_ref()
     }
 
     fn verify_certificate(
@@ -310,7 +318,7 @@ impl ServerCertVerifier for Verifier {
             message,
             cert,
             dss,
-            &self.default_provider.signature_verification_algorithms,
+            &self.get_provider().signature_verification_algorithms,
         )
     }
 
@@ -324,12 +332,12 @@ impl ServerCertVerifier for Verifier {
             message,
             cert,
             dss,
-            &self.default_provider.signature_verification_algorithms,
+            &self.get_provider().signature_verification_algorithms,
         )
     }
 
     fn supported_verify_schemes(&self) -> Vec<SignatureScheme> {
-        self.default_provider
+        self.get_provider()
             .signature_verification_algorithms
             .supported_schemes()
     }

--- a/rustls-platform-verifier/src/verification/apple.rs
+++ b/rustls-platform-verifier/src/verification/apple.rs
@@ -1,3 +1,5 @@
+use std::sync::Arc;
+
 use super::log_server_cert;
 use crate::verification::invalid_certificate;
 use core_foundation::date::CFDate;
@@ -43,7 +45,7 @@ pub struct Verifier {
     /// Testing only: The root CA certificate to trust.
     #[cfg(any(test, feature = "ffi-testing", feature = "dbg"))]
     test_only_root_ca_override: Option<Vec<u8>>,
-    default_provider: CryptoProvider,
+    default_provider: Arc<CryptoProvider>,
 }
 
 impl Verifier {
@@ -53,7 +55,9 @@ impl Verifier {
         Self {
             #[cfg(any(test, feature = "ffi-testing", feature = "dbg"))]
             test_only_root_ca_override: None,
-            default_provider: rustls::crypto::ring::default_provider(),
+            default_provider: rustls::crypto::CryptoProvider::get_default()
+                .expect("rustls default CryptoProvider not set")
+                .clone(),
         }
     }
 
@@ -62,7 +66,9 @@ impl Verifier {
     pub(crate) fn new_with_fake_root(root: &[u8]) -> Self {
         Self {
             test_only_root_ca_override: Some(root.into()),
-            default_provider: rustls::crypto::ring::default_provider(),
+            default_provider: rustls::crypto::CryptoProvider::get_default()
+                .expect("rustls default CryptoProvider not set")
+                .clone(),
         }
     }
 

--- a/rustls-platform-verifier/src/verification/windows.rs
+++ b/rustls-platform-verifier/src/verification/windows.rs
@@ -55,6 +55,7 @@ use std::{
     convert::TryInto,
     mem::{self, MaybeUninit},
     ptr::{self, NonNull},
+    sync::Arc,
 };
 
 use crate::verification::invalid_certificate;
@@ -419,7 +420,7 @@ pub struct Verifier {
     /// Testing only: The root CA certificate to trust.
     #[cfg(any(test, feature = "ffi-testing", feature = "dbg"))]
     test_only_root_ca_override: Option<Vec<u8>>,
-    default_provider: CryptoProvider,
+    default_provider: Arc<CryptoProvider>,
 }
 
 impl Verifier {
@@ -429,7 +430,9 @@ impl Verifier {
         Self {
             #[cfg(any(test, feature = "ffi-testing", feature = "dbg"))]
             test_only_root_ca_override: None,
-            default_provider: rustls::crypto::ring::default_provider(),
+            default_provider: rustls::crypto::CryptoProvider::get_default()
+                .expect("rustls default CryptoProvider not set")
+                .clone(),
         }
     }
 
@@ -438,7 +441,9 @@ impl Verifier {
     pub(crate) fn new_with_fake_root(root: &[u8]) -> Self {
         Self {
             test_only_root_ca_override: Some(root.into()),
-            default_provider: rustls::crypto::ring::default_provider(),
+            default_provider: rustls::crypto::CryptoProvider::get_default()
+                .expect("rustls default CryptoProvider not set")
+                .clone(),
         }
     }
 


### PR DESCRIPTION
Required for Quinn to update past rustls 0.21, so a release soon after would be appreciated. Also relaxes default feature requirements on rustls.