### PR TITLE
Update Android test action and fix outstanding CI issues

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -116,16 +116,30 @@ jobs:
       - name: Test (${{ matrix.os }})
         run: cargo test
 
-      - name: Setup Android test environment
+  test_android:
+    name: "Test (Android)"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      # Turn on Linux KVM features/support for faster Android emulation.
+      # References:
+      # - https://github.com/DeterminateSystems/nix-installer-action/blob/de22e16c4711fca50c816cc9081563429d1cf563/src/main.ts#L756
+      # - https://github.com/ReactiveCircus/android-emulator-runner#running-hardware-accelerated-emulators-on-linux-runners
+      - name: Enable KVM
+        run: |
+          echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
+          sudo udevadm control --reload-rules
+          sudo udevadm trigger --name-match=kvm
+
+      - name: Setup Java
         uses: actions/setup-java@v2
-        if: matrix.os == 'macos-latest'
         with:
           distribution: 'temurin'
           java-version: '11'
 
-      - name: Test (Android)
-        uses: reactivecircus/android-emulator-runner@d7b53ddc6e44254e1f4cf4a6ad67345837027a66 # 2.26.0
-        if: matrix.os == 'macos-latest'
+      - name: Run Android tests
+        uses: reactivecircus/android-emulator-runner@6b0df4b0efb23bb0ec63d881db79aefbc976e4b2 # 2.30.1
         with:
           api-level: 28 # Android 9, Pie.
           arch: x86_64
@@ -152,7 +166,7 @@ jobs:
       - name: Upload Android test results
         uses: actions/upload-artifact@v3
         # Upload test results if they fail
-        if: matrix.os == 'macos-latest' && failure()
+        if: failure()
         with:
           name: android-test-results
           retention-days: 7
@@ -160,8 +174,8 @@ jobs:
             emulator.log
             /Users/runner/work/rustls-platform-verifier/rustls-platform-verifier/android/rustls-platform-verifier/build/outputs/androidTest-results/connected/test-result.pb
 
-      # TODO: Test iOS in CI too.
-
+  # TODO: Test iOS in CI too.
+     
   test-freebsd:
     name: Test (FreeBSD)
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -160,7 +160,8 @@ jobs:
             env | grep '^JAVA'
             touch emulator.log
             chmod 770 emulator.log
-            adb logcat >> emulator.log &
+            adb logcat --clear
+            adb logcat | grep 'rustls' | tee emulator.log &
             ./gradlew connectedDebugAndroidTest
 
       - name: Upload Android test results
@@ -171,7 +172,7 @@ jobs:
           name: android-test-results
           retention-days: 7
           path: |
-            emulator.log
+            ./android/emulator.log
             /Users/runner/work/rustls-platform-verifier/rustls-platform-verifier/android/rustls-platform-verifier/build/outputs/androidTest-results/connected/test-result.pb
 
   # TODO: Test iOS in CI too.


### PR DESCRIPTION
This PR performs some maintenance on our Android testing infrastructure. Notably it:
1. Updates our Android runner action to try and pick up on bugfixes.
2. Switches the job to run on Linux instead for speed. We enable KVM on the runner as well since the Android emulator needs virtualization and that needs to be fast.
3. Moves the Android job into its own YAML area so it doesn't get confused with the host OS's tests anymore.
4. Fixes the log output and artifact upload locations

Relates to #68 