### PR TITLE
proj: add initial Nix flake support

### DIFF
--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -1,0 +1,34 @@
+on:
+  push:
+  pull_request:
+  merge_group:
+  schedule:
+    - cron: '0 18 * * *'
+
+name: Nix
+permissions:
+  contents: read
+
+jobs:
+  flake:
+    name: Nix Flake
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - name: Install Nix
+        uses: DeterminateSystems/nix-installer-action@main
+
+      - name: Setup Nix Caching
+        uses: DeterminateSystems/magic-nix-cache-action@main
+
+      - name: Check Flake & Outputs
+        run: nix flake check --all-systems
+
+      - name: Build default package
+        run: nix build .#
+
+      - name: Build debug package
+        run: nix build .#rustls-platform-verifier-dbg

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,6 @@
 /android-release-support/maven/pom.xml
 /android-release-support/maven/rustls/rustls-platform-verifier/**/
 /android-release-support/maven/rustls/rustls-platform-verifier/maven-metadata-local.xml
+
+# Nix
+/result

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,133 @@
+{
+  "nodes": {
+    "flake-parts": {
+      "inputs": {
+        "nixpkgs-lib": "nixpkgs-lib"
+      },
+      "locked": {
+        "lastModified": 1712014858,
+        "narHash": "sha256-sB4SWl2lX95bExY2gMFG5HIzvva5AVMJd4Igm+GpZNw=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "9126214d0a59633752a136528f5f3b9aa8565b7d",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "type": "github"
+      }
+    },
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1705309234,
+        "narHash": "sha256-uNRRNRKmJyCRC/8y1RqBkqWBLM034y4qN7EprSdmgyA=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "1ef2e671c3b0c19053962c07dbda38332dcebf26",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1713995372,
+        "narHash": "sha256-fFE3M0vCoiSwCX02z8VF58jXFRj9enYUSTqjyHAjrds=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "dd37924974b9202f8226ed5d74a252a9785aedf8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-23.11",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-lib": {
+      "locked": {
+        "dir": "lib",
+        "lastModified": 1711703276,
+        "narHash": "sha256-iMUFArF0WCatKK6RzfUJknjem0H9m4KgorO/p3Dopkk=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "d8fe5e6c92d0d190646fb9f1056741a229980089",
+        "type": "github"
+      },
+      "original": {
+        "dir": "lib",
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_2": {
+      "locked": {
+        "lastModified": 1706487304,
+        "narHash": "sha256-LE8lVX28MV2jWJsidW13D2qrHU/RUUONendL2Q/WlJg=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "90f456026d284c22b3e3497be980b2e47d0b28ac",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-parts": "flake-parts",
+        "nixpkgs": "nixpkgs",
+        "rust-overlay": "rust-overlay"
+      }
+    },
+    "rust-overlay": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs_2"
+      },
+      "locked": {
+        "lastModified": 1714097613,
+        "narHash": "sha256-044xbpBszupqN3nl/CGOCJtTQ4O6Aca81mJpX45i8/I=",
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "rev": "2a42c742ab04b61d9b2f1edf392842cf9f27ebfd",
+        "type": "github"
+      },
+      "original": {
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "type": "github"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,130 @@
+{
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-23.11";
+    flake-parts.url = "github:hercules-ci/flake-parts";
+    rust-overlay.url = "github:oxalica/rust-overlay";
+  };
+
+  outputs = inputs:
+    inputs.flake-parts.lib.mkFlake { inherit inputs; } {
+      # TODO(XXX): in theory this flake could support aarch64-linux,
+      #   x86_64-darwin and aarch64-darwin, but it is untested.
+      systems = [ "x86_64-linux" ];
+      perSystem = { config, self', pkgs, lib, system, ... }:
+        let
+          buildToolsVersion = "30.0.3";
+          platformVersion = "33";
+          rustTargets = [ "${system}-android" ];
+          abi = (lib.systems.elaborate system).linuxArch;
+
+          devDeps = with pkgs; [
+            android-sdk
+            android-studio
+            maven
+            jdk11 # Matched to CI setup-java task's java-version
+            der-ascii
+          ];
+
+          android-comp = pkgs.androidenv.composeAndroidPackages {
+            buildToolsVersions = [ buildToolsVersion ];
+            platformVersions = [ platformVersion ];
+            abiVersions = [ abi ];
+
+            # Note: Pinned presently to NDK 23 specifically to workaround an issue
+            # with the bundled clang missing libc++ in NDK 24. We can't use NDK
+            # 22, as it's too old for cargo-ndk.
+            ndkVersion = "23.1.7779620";
+
+            systemImageTypes = [ "default" ];
+
+            includeNDK = true;
+            includeEmulator = true;
+            includeSystemImages = true;
+          };
+
+          # Note: additional flags can be provided to emulator through
+          #   the $NIX_ANDROID_EMULATOR_FLAGS env var.
+          android-emu = pkgs.androidenv.emulateApp {
+            name = "emulate-PlatformVerifier";
+            platformVersion = platformVersion;
+            abiVersion = abi;
+            systemImageType = "default";
+
+            # Note: Depending on your hardware you may wish to enable or disable
+            # this option.
+            enableGPU = false;
+          };
+
+          android-sdk = android-comp.androidsdk;
+          android-sdk-root = "${android-sdk}/libexec/android-sdk";
+
+          verifierCargoToml = builtins.fromTOML
+            (builtins.readFile ./rustls-platform-verifier/Cargo.toml);
+          msrv = verifierCargoToml.package.rust-version;
+
+          verifierPackage = features:
+            (pkgs.makeRustPlatform {
+              cargo = pkgs.rust-bin.stable.latest.minimal;
+              rustc = pkgs.rust-bin.stable.latest.minimal;
+            }).buildRustPackage {
+              inherit (verifierCargoToml.package) name version;
+              src = ./.;
+              buildAndTestSubdir = "rustls-platform-verifier";
+              cargoLock.lockFile = ./Cargo.lock;
+              buildFeatures = features;
+              doCheck = false; # Some tests require networking
+            };
+
+          mkDevShell = rustc:
+            pkgs.mkShell {
+              ANDROID_HOME = "${android-sdk-root}";
+              ANDROID_SDK_ROOT = "${android-sdk-root}";
+              ANDROID_NDK_ROOT = "${android-sdk-root}/ndk-bundle";
+              JAVA_HOME = "${pkgs.jdk11}";
+              # Note: It's important to set this so that gradle uses the correct
+              #   aapt2 binary.
+              GRADLE_OPTS =
+                "-Dorg.gradle.project.android.aapt2FromMavenOverride=${android-sdk-root}/build-tools/${buildToolsVersion}/aapt2";
+              shellHook = ''
+                export RUST_SRC_PATH=${pkgs.rustPlatform.rustLibSrc}
+                echo 1>&2 "🔒🔍 rustls-platform-verifier"
+              '';
+              nativeBuildInputs = devDeps ++ [ rustc ];
+            };
+
+        in {
+          _module.args.pkgs = import inputs.nixpkgs {
+            inherit system;
+            overlays = [ (import inputs.rust-overlay) ];
+            config = {
+              # Allow unfree packages and agree to the Android SDK terms of service.
+              # Review https://developer.android.com/studio/terms before use.
+              allowUnfree = true;
+              android_sdk.accept_license = true;
+            };
+          };
+
+          # Base library.
+          packages.rustls-platform-verifier = (verifierPackage [ ]);
+          # Library with debug extras.
+          packages.rustls-platform-verifier-dbg =
+            (verifierPackage [ "dbg" "base64" "docsrs" ]);
+          # Test emulator.
+          packages.android-emu = android-emu;
+          packages.default = self'.packages.rustls-platform-verifier;
+
+          devShells.nightly = (mkDevShell (pkgs.rust-bin.selectLatestNightlyWith
+            (toolchain:
+              toolchain.default.override { targets = rustTargets; })));
+          devShells.stable = (mkDevShell
+            (pkgs.rust-bin.stable.latest.default.override {
+              targets = rustTargets;
+            }));
+          devShells.msrv = (mkDevShell
+            (pkgs.rust-bin.stable.${msrv}.default.override {
+              targets = rustTargets;
+            }));
+          devShells.default = self'.devShells.nightly;
+        };
+    };
+}


### PR DESCRIPTION
The tooling required to work in this repo can be a little bit challenging to set up (largely as a side effect of supporting multiple platforms/languages, each with their own tooling requirements).

In an effort to make this easier and more reproducible this commit adds the start of a [Nix flake](https://zero-to-nix.com/concepts/flakes).

Some starting points (assuming you've set up `nix`, which is outside of the scope of this PR):

* `nix build .` - builds the platform verifier Rust library in a release configuration using stable Rust.
* `nix build .#rustls-platform-verifier-dbg` - same as above, but with the "dbg", "base64", and "docsrs" Cargo features enabled.
* `nix develop` - enter a development shell offering a nightly rust toolchain, Android studio, Android SDK/NDK, Java, and Maven tools for building the Android project and using the release tooling.
* `nix develop .#stable` - same as above, but with the stable Rust toolchain.
* `nix develop .#msrv` - same as above, but with the project MSRV Rust toolchain.

There's also an `android-emu` output for creating an Android device emulator that can be used to run unit tests:

```
# Terminal 1 - Android emulator
nix develop
nix build .#android-emu
./result/bin/run-test-emulator&
adb devices
adb logcat
```

```
# Terminal 2 - Unit tests
nix develop
pushd android && ./gradlew connectedAndroidTest
```

Future work:

* The NDK version is presently pinned to a 23.x version to avoid a clang libc++ error. This should be resolved so we can use 24.x (Some [debugging notes here](https://gist.github.com/cpu/d67e41030196d3fe7f5c00fe50aa2f28))
* Support for additional platforms. I believe most of this will work on other systems/targets but I've only tested on x86_64 so have left out additional support for now
* ~It should be possible to configure an Android emulator, and to run the unit tests within the emulator, without using Android studio or manually configuring an emulator.~ I added an output to create an emulator device.
* ~I'm not sure whether there's interest in CI integration. It might be a good idea to add a `nix build` step somewhere to try and prevent bitrot.~ I added a CI task.