### PR TITLE
ci: use default Android emulator target

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -144,13 +144,6 @@ jobs:
           api-level: 28 # Android 9, Pie.
           arch: x86_64
           profile: pixel
-          # Note: We use the `google_apis` target because the default one doesn't have access to
-          # the internet for the real-world test suite. The intermediate certificate doesn't have
-          # stapled revocation data, so the system must look it up instead.
-          #
-          # This can use the default target (which is less bloated) once
-          # https://github.com/ReactiveCircus/android-emulator-runner/issues/220 is resolved.
-          target: google_apis
           emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
           disable-animations: true
           working-directory: ./android


### PR DESCRIPTION
Previously the Android emulator based CI job was using the larger `googles_api` target instead of the slimmer default. This was done to ensure network access worked as intended for the real-world test suite with a TODO to revisit after an upstream bug was fixed:

https://github.com/rustls/rustls-platform-verifier/blob/d68c2edd4c5fb2aa4cde57f472de059e6966f64c/.github/workflows/ci.yml#L147-L153

In the meantime the upstream bug has been closed and we've upgraded the emulator action version. Let's try the default target again and hopefully get a small CI speedup. It appears to [run without error](https://github.com/cpu/rustls-platform-verifier/actions/runs/8253588317) in my testing.