### PR TITLE
Cargo: version 0.2.0 -> 0.3.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -307,7 +307,7 @@ checksum = "5ede67b28608b4c60685c7d54122d4400d90f62b40caee7700e700380a390fa8"
 
 [[package]]
 name = "rustls-platform-verifier"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "android_logger",
  "base64",

--- a/rustls-platform-verifier/Cargo.toml
+++ b/rustls-platform-verifier/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rustls-platform-verifier"
-version = "0.2.0"
+version = "0.3.0"
 authors = ["ComplexSpaces <complexspacescode@gmail.com>", "1Password"]
 description = "rustls-platform-verifier supports verifying TLS certificates in rustls with the operating system verifier"
 keywords = ["tls", "certificate", "verification", "os", "native"]


### PR DESCRIPTION
This branch prepares a 0.3.0 release, primarily to publish the rustls update (https://github.com/rustls/rustls-platform-verifier/pull/70)


## Proposed release notes

* Updates Rustls from 0.22 to 0.23.

### Post-merge steps

- [ ] Generate Android Maven artifacts locally
- [ ] Create and push Git tag
- [ ] `cargo publish` for each required crate, based on release steps
- [ ] Create companion GitHub release