### PR TITLE
Added tvOS support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,8 +16,25 @@ env:
   RUSTFLAGS: -D warnings -F unused_must_use
 
 jobs:
+  clippy-build-std:
+    name: Clippy (-Zbuild-std)
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - uses: dtolnay/rust-toolchain@nightly
+        with:
+          components: clippy
+
+      - name: Clippy (tvOS)
+        run: |
+          rustup component add rust-src --toolchain nightly-x86_64-apple-darwin
+          cargo +nightly clippy -Zbuild-std --target aarch64-apple-tvos
+
   clippy:
-    name: Clippy
+    name: Clippy (stable)
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -361,9 +361,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework"
-version = "2.9.2"
+version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05b64fb303737d99b81884b2c63433e9ae28abebe5eb5045dcdd175dc2ecf4de"
+checksum = "770452e37cad93e0a50d5abc3990d2bc351c36d0328f86cefec2f2fb206eaef6"
 dependencies = [
  "bitflags",
  "core-foundation",
@@ -375,9 +375,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework-sys"
-version = "2.9.1"
+version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e932934257d3b408ed8f30db49d85ea163bfe74961f017f405b025af298f0c7a"
+checksum = "41f3cc463c0ef97e11c3461a9d3787412d30e8e7eb907c79180c4a57bf7c04ef"
 dependencies = [
  "core-foundation-sys",
  "libc",

--- a/rustls-platform-verifier/Cargo.toml
+++ b/rustls-platform-verifier/Cargo.toml
@@ -35,7 +35,7 @@ base64 = { version = "0.21", optional = true } # Only used when the `cert-loggin
 jni = { version = "0.19", default-features = false, optional = true } # Only used during doc generation
 once_cell = "1.9"
 
-[target.'cfg(all(unix, not(target_os = "android"), not(target_os = "macos"), not(target_os = "ios")))'.dependencies]
+[target.'cfg(all(unix, not(target_os = "android"), not(target_os = "macos"), not(target_os = "ios"), not(target_os = "tvos")))'.dependencies]
 rustls-native-certs = "0.7"
 webpki = { package = "rustls-webpki", version = "0.102", features = ["ring", "alloc", "std"] }
 
@@ -52,11 +52,11 @@ webpki-roots = "0.26"
 [target.'cfg(target_os = "freebsd")'.dev-dependencies]
 webpki-roots = "0.26"
 
-[target.'cfg(any(target_os = "macos", target_os = "ios"))'.dependencies]
+[target.'cfg(any(target_os = "macos", target_os = "ios", target_os = "tvos"))'.dependencies]
 core-foundation = "0.9"
 core-foundation-sys = "0.8"
-security-framework = { version = "2.6", features = ["OSX_10_14"] }
-security-framework-sys = { version = "2.4", features = ["OSX_10_14"] }
+security-framework = { version = "2.10", features = ["OSX_10_14"] }
+security-framework-sys = { version = "2.10", features = ["OSX_10_14"] }
 
 [target.'cfg(windows)'.dependencies]
 winapi = { version = "0.3", features = ["wincrypt", "winerror"] }

--- a/rustls-platform-verifier/src/tests/verification_mock/mod.rs
+++ b/rustls-platform-verifier/src/tests/verification_mock/mod.rs
@@ -13,7 +13,11 @@
 //! any parts of the system outside of these tests. See the `#![cfg(...)]`
 //! immediately below to see which platforms run these tests.
 
-#![cfg(all(any(windows, unix, target_os = "android"), not(target_os = "ios")))]
+#![cfg(all(
+    any(windows, unix, target_os = "android"),
+    not(target_os = "ios"),
+    not(target_os = "tvos")
+))]
 
 use super::TestCase;
 use crate::tests::{assert_cert_error_eq, ensure_global_state, verification_time};

--- a/rustls-platform-verifier/src/verification/mod.rs
+++ b/rustls-platform-verifier/src/verification/mod.rs
@@ -2,7 +2,8 @@
     any(unix, target_arch = "wasm32"),
     not(target_os = "android"),
     not(target_os = "macos"),
-    not(target_os = "ios")
+    not(target_os = "ios"),
+    not(target_os = "tvos")
 ))]
 mod others;
 
@@ -10,14 +11,15 @@ mod others;
     any(unix, target_arch = "wasm32"),
     not(target_os = "android"),
     not(target_os = "macos"),
-    not(target_os = "ios")
+    not(target_os = "ios"),
+    not(target_os = "tvos")
 ))]
 pub use others::Verifier;
 
-#[cfg(any(target_os = "macos", target_os = "ios"))]
+#[cfg(any(target_os = "macos", target_os = "ios", target_os = "tvos"))]
 mod apple;
 
-#[cfg(any(target_os = "macos", target_os = "ios"))]
+#[cfg(any(target_os = "macos", target_os = "ios", target_os = "tvos"))]
 pub use apple::Verifier;
 
 #[cfg(target_os = "android")]
@@ -61,7 +63,7 @@ fn log_server_cert(_end_entity: &rustls::pki_types::CertificateDer<'_>) {
 
 // Unknown certificate error shorthand. Used when we need to construct an "Other" certificate
 // error with a platform specific error message.
-#[cfg(any(windows, target_os = "macos", target_os = "ios"))]
+#[cfg(any(windows, target_os = "macos", target_os = "ios", target_os = "tvos"))]
 fn invalid_certificate(reason: impl Into<String>) -> rustls::Error {
     rustls::Error::InvalidCertificate(rustls::CertificateError::Other(rustls::OtherError(
         std::sync::Arc::from(Box::from(reason.into())),


### PR DESCRIPTION
Added support to build tvOS targets so that consumers of [rustls-platform-verifier](https://github.com/rustls/rustls-platform-verifier) can use it with tvOS devices

Target support added for:
- x86_64-apple-tvos
- aarch64-apple-tvos
- aarch64-apple-tvos-sim

Motivation:
- We are adding support for tvOS to our library and consuming iOS application that relies on this Rust dependency directly. 

How was this tested:
- cargo test (passed)
- cargo +nightly build -Z build-std --lib --target x86_64-apple-tvos -v
- cargo +nightly build -Z build-std --lib --target aarch64-apple-tvos-v
- cargo +nightly build -Z build-std --lib --target aarch64-apple-tvos-sim -v