### PR TITLE
feat: add Verifier::set_provider and Verifier::with_provider

### DIFF
--- a/rustls-platform-verifier/src/verification/android.rs
+++ b/rustls-platform-verifier/src/verification/android.rs
@@ -47,7 +47,7 @@ pub struct Verifier {
     /// Testing only: The root CA certificate to trust.
     #[cfg(any(test, feature = "ffi-testing"))]
     test_only_root_ca_override: Option<Vec<u8>>,
-    default_provider: OnceCell<Arc<CryptoProvider>>,
+    pub(super) crypto_provider: OnceCell<Arc<CryptoProvider>>,
 }
 
 impl Default for Verifier {
@@ -71,13 +71,16 @@ impl Drop for Verifier {
 
 impl Verifier {
     /// Creates a new instance of a TLS certificate verifier that utilizes the
-    /// Android certificate facilities. The rustls default [`CryptoProvider`]
-    /// must be set before the verifier can be used.
+    /// Android certificate facilities.
+    ///
+    /// A [`CryptoProvider`] must be set with
+    /// [`set_provider`][Verifier::set_provider]/[`with_provider`][Verifier::with_provider] or
+    /// [`CryptoProvider::install_default`] before the verifier can be used.
     pub fn new() -> Self {
         Self {
             #[cfg(any(test, feature = "ffi-testing"))]
             test_only_root_ca_override: None,
-            default_provider: OnceCell::new(),
+            crypto_provider: OnceCell::new(),
         }
     }
 
@@ -86,18 +89,8 @@ impl Verifier {
     pub(crate) fn new_with_fake_root(root: &[u8]) -> Self {
         Self {
             test_only_root_ca_override: Some(root.into()),
-            default_provider: OnceCell::new(),
+            crypto_provider: OnceCell::new(),
         }
-    }
-
-    fn get_provider(&self) -> &CryptoProvider {
-        self.default_provider
-            .get_or_init(|| {
-                rustls::crypto::CryptoProvider::get_default()
-                    .expect("rustls default CryptoProvider not set")
-                    .clone()
-            })
-            .as_ref()
     }
 
     fn verify_certificate(

--- a/rustls-platform-verifier/src/verification/windows.rs
+++ b/rustls-platform-verifier/src/verification/windows.rs
@@ -421,18 +421,21 @@ pub struct Verifier {
     /// Testing only: The root CA certificate to trust.
     #[cfg(any(test, feature = "ffi-testing", feature = "dbg"))]
     test_only_root_ca_override: Option<Vec<u8>>,
-    default_provider: OnceCell<Arc<CryptoProvider>>,
+    pub(super) crypto_provider: OnceCell<Arc<CryptoProvider>>,
 }
 
 impl Verifier {
     /// Creates a new instance of a TLS certificate verifier that utilizes the
-    /// Windows certificate facilities. The rustls default [`CryptoProvider`]
-    /// must be set before the verifier can be used.
+    /// Windows certificate facilities.
+    ///
+    /// A [`CryptoProvider`] must be set with
+    /// [`set_provider`][Verifier::set_provider]/[`with_provider`][Verifier::with_provider] or
+    /// [`CryptoProvider::install_default`] before the verifier can be used.
     pub fn new() -> Self {
         Self {
             #[cfg(any(test, feature = "ffi-testing", feature = "dbg"))]
             test_only_root_ca_override: None,
-            default_provider: OnceCell::new(),
+            crypto_provider: OnceCell::new(),
         }
     }
 
@@ -441,18 +444,8 @@ impl Verifier {
     pub(crate) fn new_with_fake_root(root: &[u8]) -> Self {
         Self {
             test_only_root_ca_override: Some(root.into()),
-            default_provider: OnceCell::new(),
+            crypto_provider: OnceCell::new(),
         }
-    }
-
-    fn get_provider(&self) -> &CryptoProvider {
-        self.default_provider
-            .get_or_init(|| {
-                rustls::crypto::CryptoProvider::get_default()
-                    .expect("rustls default CryptoProvider not set")
-                    .clone()
-            })
-            .as_ref()
     }
 
     /// Verifies a certificate and its chain for the specified `server`.


### PR DESCRIPTION
This is offered as a possible solution for #79, which I just encountered.

Implementation notes, let me know if any of these assumptions were wrong:

* I renamed `default_provider` fields to `crypto_provider` to make clear that it's not necessarily the process-default.
* I added both a `set_provider` and `with_provider`, the latter of which is convenient for `Verifier::new().with_provider(Arc::new(...))` but I'll replace with `Verifier::new_with_provider(...)` if that's more in line with this crate's style.
* ~I opted to panic if the crypto provider has already been set instead of returning an indication of failure, with the expectation that it's a bug if this is called multiple times on a given `Verifier`.~ We have `&mut`, no panic or error needed