### PR TITLE
Vet docs in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -229,3 +229,20 @@ jobs:
       
       - name: Verify release artifact
         run: ./ci/verify_android_release.sh
+
+  docs:
+    name: Check for documentation errors
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v3
+        with:
+          persist-credentials: false
+
+      - name: Install rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Build documentation
+        run: cargo doc --locked --all-features --no-deps --document-private-items
+        env:
+          RUSTDOCFLAGS: -Dwarnings

--- a/rustls-platform-verifier/src/tests/mod.rs
+++ b/rustls-platform-verifier/src/tests/mod.rs
@@ -52,7 +52,7 @@ pub fn assert_cert_error_eq<E: StdError + PartialEq + 'static>(
     }
 }
 
-/// Return a fixed [SystemTime] for certificate validation purposes.
+/// Return a fixed [`pki_types::UnixTime`] for certificate validation purposes.
 ///
 /// We fix the "now" value used for certificate validation to a fixed point in time at which
 /// we know the test certificates are valid. This must be updated if the mock certificates


### PR DESCRIPTION
Quick follow-up to https://github.com/rustls/rustls-platform-verifier/pull/80

It looks like this repo wasn't building documentation in CI. This branch adds a step for that, forbidding warnings. Additionally fixes a warning in test-only rustdoc that is raised when using `--document-private-items`.