### PR TITLE
feat: rustls_platform_verifier::tls_config_with_provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,13 @@ To get a rustls `ClientConfig` configured to use the platform verifier use:
 let config = rustls_platform_verifier::tls_config();
 ```
 
+This crate will use the [rustls process-default crypto provider](https://docs.rs/rustls/latest/rustls/crypto/struct.CryptoProvider.html#using-the-per-process-default-cryptoprovider). To construct a `ClientConfig` with a different `CryptoProvider`, use:
+
+```rust
+let arc_crypto_provider = std::sync::Arc::new(rustls::crypto::ring::default_provider());
+let config = rustls_platform_verifier::tls_config_with_provider(arc_crypto_provider);
+```
+
 If you want to adapt the configuration, you can build the `ClientConfig` like this:
 
 ```rust

--- a/rustls-platform-verifier/src/lib.rs
+++ b/rustls-platform-verifier/src/lib.rs
@@ -65,6 +65,25 @@ pub fn tls_config() -> ClientConfig {
         .with_no_client_auth()
 }
 
+/// Attempts to construct a `rustls` configuration that verifies TLS certificates in the best way
+/// for the underlying OS platform, using the provided
+/// [`CryptoProvider`][rustls::crypto::CryptoProvider].
+///
+/// See [`tls_config`] for further documentation.
+///
+/// # Errors
+///
+/// Propagates any error returned by [`rustls::ConfigBuilder::with_safe_default_protocol_versions`].
+pub fn tls_config_with_provider(
+    provider: Arc<rustls::crypto::CryptoProvider>,
+) -> Result<ClientConfig, rustls::Error> {
+    Ok(ClientConfig::builder_with_provider(provider.clone())
+        .with_safe_default_protocol_versions()?
+        .dangerous()
+        .with_custom_certificate_verifier(Arc::new(Verifier::new().with_provider(provider)))
+        .with_no_client_auth())
+}
+
 /// Exposed for debugging certificate issues with standalone tools.
 ///
 /// This is not intended for production use, you should use [tls_config] instead.


### PR DESCRIPTION
The primary entry point for this crate `tls_config` is quite convenient, but opting out of that in order to configure a crypto provider adds a bit more complexity and opportunity for misconfiguration. This PR offers a solution to "do what `tls_config` does, but with a crypto provider".


based on #81 