### PR TITLE
0.3.1 release preparation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -307,7 +307,7 @@ checksum = "5ede67b28608b4c60685c7d54122d4400d90f62b40caee7700e700380a390fa8"
 
 [[package]]
 name = "rustls-platform-verifier"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "android_logger",
  "base64",

--- a/rustls-platform-verifier/Cargo.toml
+++ b/rustls-platform-verifier/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rustls-platform-verifier"
-version = "0.3.0"
+version = "0.3.1"
 authors = ["ComplexSpaces <complexspacescode@gmail.com>", "1Password"]
 description = "rustls-platform-verifier supports verifying TLS certificates in rustls with the operating system verifier"
 keywords = ["tls", "certificate", "verification", "os", "native"]


### PR DESCRIPTION
## Proposed release notes

* New `rustls_platform_verifier::tls_config_with_provider()` function for convenient construction of a `rustls::ClientConfig` configured with the platform verifier, and a specific [`rustls::crypto::CryptoProvider`](https://docs.rs/rustls/latest/rustls/crypto/struct.CryptoProvider.html).
* New `Verifier::with_provider()` and `Verifier::set_provider()` fns for constructing or updating a `Verifier` with a specific [`rustls::crypto::CryptoProvider`](https://docs.rs/rustls/latest/rustls/crypto/struct.CryptoProvider.html).
* Support for Apple tvOS.

### Post-merge steps

- [ ] Generate Android Maven artifacts locally
- [ ] Create and push Git tag
- [ ] `cargo publish` for each required crate, based on release steps
- [ ] Create companion GitHub release