### PR TITLE
Minimise features demanded from rustls-webpki crate

### DIFF
--- a/rustls-platform-verifier/Cargo.toml
+++ b/rustls-platform-verifier/Cargo.toml
@@ -37,12 +37,12 @@ once_cell = "1.9"
 
 [target.'cfg(all(unix, not(target_os = "android"), not(target_os = "macos"), not(target_os = "ios"), not(target_os = "tvos")))'.dependencies]
 rustls-native-certs = "0.7"
-webpki = { package = "rustls-webpki", version = "0.102", features = ["ring", "alloc", "std"] }
+webpki = { package = "rustls-webpki", version = "0.102", default-features = false }
 
 [target.'cfg(target_os = "android")'.dependencies]
 rustls-platform-verifier-android = { path = "../android-release-support", version = "0.1.0" }
 jni = { version = "0.19", default-features = false }
-webpki = { package = "rustls-webpki", version = "0.102", features = ["ring", "alloc", "std"] }
+webpki = { package = "rustls-webpki", version = "0.102", default-features = false }
 android_logger = { version = "0.13", optional = true } # Only used during testing.
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]

--- a/rustls-platform-verifier/src/verification/mod.rs
+++ b/rustls-platform-verifier/src/verification/mod.rs
@@ -40,6 +40,7 @@ pub use windows::Verifier;
 /// An EKU was invalid for the use case of verifying a server certificate.
 ///
 /// This error is used primarily for tests.
+#[cfg_attr(windows, allow(dead_code))] // not used by windows verifier
 #[derive(Debug, PartialEq)]
 pub(crate) struct EkuError;
 


### PR DESCRIPTION
This dependency exists so this crate can access
`webpki::Error` and `webpki::Error::RequiredEkuNotFound`, which are unconditionally available.

fixes #102 