### PR TITLE
Cargo: version 0.3.1 -> 0.3.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -307,7 +307,7 @@ checksum = "5ede67b28608b4c60685c7d54122d4400d90f62b40caee7700e700380a390fa8"
 
 [[package]]
 name = "rustls-platform-verifier"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "android_logger",
  "base64",

--- a/rustls-platform-verifier/Cargo.toml
+++ b/rustls-platform-verifier/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rustls-platform-verifier"
-version = "0.3.1"
+version = "0.3.2"
 authors = ["ComplexSpaces <complexspacescode@gmail.com>", "1Password"]
 description = "rustls-platform-verifier supports verifying TLS certificates in rustls with the operating system verifier"
 keywords = ["tls", "certificate", "verification", "os", "native"]


### PR DESCRIPTION
This cuts a new release bringing in [some changes since 0.3.1](https://github.com/rustls/rustls-platform-verifier/compare/v/0.3.1...c058b1c).

## Proposed release notes

* Fixed loading of native certificates using `rustls-native-certs` on FreeBSD systems using the `webpki` based UNIX verifier.
* Reduced transitive dependencies for platforms requiring a `webpki` dependency. Notably this avoids the unconditional inclusion of `ring`.

## Post-merge steps

- [x] Generate Android Maven artifacts locally -  N/A - no non-test changes made under android/
- [ ] Create and push Git tag
- [ ] `cargo publish` for each required crate, based on release steps
- [ ] Create companion GitHub release