### PR TITLE
Android: Don't attempt to check revocation on non-public certificates

### DIFF
--- a/android/.gitignore
+++ b/android/.gitignore
@@ -8,3 +8,4 @@
 .externalNativeBuild
 .cxx
 local.properties
+emulator.log

--- a/android/rustls-platform-verifier/src/androidTest/java/org/rustls/platformverifier/CertificateVerifierTests.kt
+++ b/android/rustls-platform-verifier/src/androidTest/java/org/rustls/platformverifier/CertificateVerifierTests.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
 import org.junit.BeforeClass
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -49,5 +50,23 @@ class CertificateVerifierTests {
         val context = InstrumentationRegistry.getInstrumentation().targetContext
         val result = verifyMockRootUsage(context)
         assertEquals(FAILURE_MSG, SUCCESS_MARKER, result)
+    }
+
+    // Note:
+    //
+    // - Full negative path (`CertificateVerifier`'s flow for unknown roots,
+    // are already exercised via `runMockTestSuite`).
+    //
+    // - Full positive path (`CertificateVerifier`'s flow for known roots,
+    // partial-chain revocation checks) already exercised via `runRealWorldTestSuite`.
+    @Test
+    fun runTestIsPublicRoot() {
+        val rootCAs = CertificateVerifier.getSystemRootCAs()
+
+        // Positive - can ID known roots
+        assertTrue(rootCAs.isNotEmpty())
+        for (ca in rootCAs) {
+            assertTrue(CertificateVerifier.isKnownRoot(ca))
+        }
     }
 }

--- a/rustls-platform-verifier/src/tests/verification_mock/mod.rs
+++ b/rustls-platform-verifier/src/tests/verification_mock/mod.rs
@@ -176,10 +176,23 @@ mock_root_test_cases! {
         expected_result: Ok(()),
         other_error: no_error!(),
     },
-    // Uses a separate certificate from the one used in the "good" case to deal
+
+    // The revocation tests use a separate certificate from the one used in the "good" case to deal
     // with operating systems with validation data caches (e.g. Windows).
     // Linux is not included, since the webpki verifier does not presently support OCSP revocation
     // checking.
+
+    // Check that self-signed certificates, which may or may not be revokved, do not return any
+    // kind of revocation error. It is expected that non-public certificates without revocation information
+    // have no revocation checking performed across platforms.
+    revoked_dns [ any(windows, target_os = "android", target_os = "macos") ] => TestCase {
+        reference_id: EXAMPLE_COM,
+        chain: &[include_bytes!("root1-int1-ee_example.com-revoked.crt"), ROOT1_INT1],
+        stapled_ocsp: None,
+        verification_time: verification_time(),
+        expected_result: Ok(()),
+        other_error: no_error!(),
+    },
     stapled_revoked_dns [ any(windows, target_os = "android", target_os = "macos") ] => TestCase {
         reference_id: EXAMPLE_COM,
         chain: &[include_bytes!("root1-int1-ee_example.com-revoked.crt"), ROOT1_INT1],


### PR DESCRIPTION
This PR fixes an issue on Android where the verifier was attempting to enforce revocation constraints even on self-signed certificates that don't (nor should need to) supply revocation information. This PR fixes this by bringing back our previous `isKnownRoot` check and using this to determine if we should even try the revocation codepaths. If a certificate isn't a known root, we don't let Android enforce revocation information.

A small cutout was left for cases where an explicit stapled OSCP response is provided by the server. This is for two reasons:
- Our test suite needs to be able to verify a mocked, frozen-in-time, OCSP response is confirmed as revoked.
- There _might_ be a case where someone has this setup in the real world and they are probably expecting the OSCP data to be checked by clients.

Closes https://github.com/rustls/rustls-platform-verifier/issues/69