### PR TITLE
Ensure license files are included in published crates

### DIFF
--- a/android-release-support/LICENSE-APACHE
+++ b/android-release-support/LICENSE-APACHE
@@ -1,0 +1,1 @@
+../LICENSE-APACHE

--- a/android-release-support/LICENSE-MIT
+++ b/android-release-support/LICENSE-MIT
@@ -1,0 +1,1 @@
+../LICENSE-MIT

--- a/rustls-platform-verifier/LICENSE-APACHE
+++ b/rustls-platform-verifier/LICENSE-APACHE
@@ -1,0 +1,1 @@
+../LICENSE-APACHE

--- a/rustls-platform-verifier/LICENSE-MIT
+++ b/rustls-platform-verifier/LICENSE-MIT
@@ -1,0 +1,1 @@
+../LICENSE-MIT


### PR DESCRIPTION
Both the Apache-2.0 and MIT licenses require that redistributed sources contain a copy of the original license text.

The fact that it is missing here but other rustls projects all do this correctly makes me think that this was simply an oversight when this new project was set up.