### PR TITLE
android-release-support 0.1.1, rustls-platform-verifier 0.3.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -328,7 +328,7 @@ dependencies = [
 
 [[package]]
 name = "rustls-platform-verifier-android"
-version = "0.1.0"
+version = "0.1.1"
 
 [[package]]
 name = "rustls-webpki"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -307,7 +307,7 @@ checksum = "5ede67b28608b4c60685c7d54122d4400d90f62b40caee7700e700380a390fa8"
 
 [[package]]
 name = "rustls-platform-verifier"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "android_logger",
  "base64",

--- a/android-release-support/Cargo.toml
+++ b/android-release-support/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rustls-platform-verifier-android"
-version = "0.1.0"
+version = "0.1.1"
 description = "The internal JVM support component of the rustls-platform-verifier crate. You shouldn't depend on this directly."
 repository = "https://github.com/rustls/rustls-platform-verifier"
 license = "MIT OR Apache-2.0"

--- a/rustls-platform-verifier/Cargo.toml
+++ b/rustls-platform-verifier/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rustls-platform-verifier"
-version = "0.3.2"
+version = "0.3.3"
 authors = ["ComplexSpaces <complexspacescode@gmail.com>", "1Password"]
 description = "rustls-platform-verifier supports verifying TLS certificates in rustls with the operating system verifier"
 keywords = ["tls", "certificate", "verification", "os", "native"]


### PR DESCRIPTION
## Proposed release notes

* Fixed inclusion of relevant license files in published crates.
* Android: revocation checking is no longer attempted for non-public certificates from private PKIs.

## Post-merge steps

- [ ] Generate Android Maven artifacts locally 
- [ ] Create and push Git tag
- [ ] `cargo publish` for each required crate, based on release steps
- [ ] Create companion GitHub release