### PR TITLE
small chores

### DIFF
--- a/admin/RELEASING.md
+++ b/admin/RELEASING.md
@@ -26,7 +26,7 @@ In the release preparation PR, the releaser may include the following checklist 
         * We typically name these branches `rel-xxx` where `xxx` is the major version.
         * We typically leave these branches around for future maintenance releases.
     4. Run `ci/package_android_release.sh` in a UNIX compatible shell
-    5. (Optional) `cargo publish -p rustls-platform-verifier-android --dry-run --alow-dirty`
+    5. (Optional) `cargo publish -p rustls-platform-verifier-android --dry-run --allow-dirty`
         * `--allow-dirty` is required because we don't check-in the generated Maven local repository.
     6. (Optional) Inspect extracted archive to ensure the local Maven repository artifacts are present
         1. Un-tar the `rustls-platform-verifier-android-*.crate` file inside of `target/package`.
@@ -35,7 +35,7 @@ In the release preparation PR, the releaser may include the following checklist 
            unzipped package's `Cargo.toml` as a replacement for the `manifestPath` variable. Run a Gradle Sync and observe everything works.
     7. **Ensure that all version changes are committed to the correct branch before proceeding**. All version increases should be checked in prior
        to publishing on crates.io.
-    8. Publish the Android artifacts' new version: `cargo publish -p rustls-platform-verifier-android --alow-dirty`
+    8. Publish the Android artifacts' new version: `cargo publish -p rustls-platform-verifier-android --allow-dirty`
 
 3. Commit main crate's version increase on the release branch
 4. **Ensure that all version changes are committed to the correct branch before proceeding**. All version increases should be checked in prior

--- a/flake.lock
+++ b/flake.lock
@@ -5,11 +5,11 @@
         "nixpkgs-lib": "nixpkgs-lib"
       },
       "locked": {
-        "lastModified": 1712014858,
-        "narHash": "sha256-sB4SWl2lX95bExY2gMFG5HIzvva5AVMJd4Igm+GpZNw=",
+        "lastModified": 1719994518,
+        "narHash": "sha256-pQMhCCHyQGRzdfAkdJ4cIWiw+JNuWsTX7f0ZYSyz0VY=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "9126214d0a59633752a136528f5f3b9aa8565b7d",
+        "rev": "9227223f6d922fee3c7b190b2cc238a99527bbb7",
         "type": "github"
       },
       "original": {
@@ -54,20 +54,14 @@
     },
     "nixpkgs-lib": {
       "locked": {
-        "dir": "lib",
-        "lastModified": 1711703276,
-        "narHash": "sha256-iMUFArF0WCatKK6RzfUJknjem0H9m4KgorO/p3Dopkk=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "d8fe5e6c92d0d190646fb9f1056741a229980089",
-        "type": "github"
+        "lastModified": 1719876945,
+        "narHash": "sha256-Fm2rDDs86sHy0/1jxTOKB1118Q0O3Uc7EC0iXvXKpbI=",
+        "type": "tarball",
+        "url": "https://github.com/NixOS/nixpkgs/archive/5daf0514482af3f97abaefc78a6606365c9108e2.tar.gz"
       },
       "original": {
-        "dir": "lib",
-        "owner": "NixOS",
-        "ref": "nixos-unstable",
-        "repo": "nixpkgs",
-        "type": "github"
+        "type": "tarball",
+        "url": "https://github.com/NixOS/nixpkgs/archive/5daf0514482af3f97abaefc78a6606365c9108e2.tar.gz"
       }
     },
     "nixpkgs_2": {

--- a/flake.lock
+++ b/flake.lock
@@ -38,16 +38,16 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1713995372,
-        "narHash": "sha256-fFE3M0vCoiSwCX02z8VF58jXFRj9enYUSTqjyHAjrds=",
+        "lastModified": 1722087241,
+        "narHash": "sha256-2ShmEaFi0kJVOEEu5gmlykN5dwjWYWYUJmlRTvZQRpU=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "dd37924974b9202f8226ed5d74a252a9785aedf8",
+        "rev": "8c50662509100d53229d4be607f1a3a31157fa12",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "nixos-23.11",
+        "ref": "nixos-24.05",
         "repo": "nixpkgs",
         "type": "github"
       }

--- a/flake.lock
+++ b/flake.lock
@@ -18,24 +18,6 @@
         "type": "github"
       }
     },
-    "flake-utils": {
-      "inputs": {
-        "systems": "systems"
-      },
-      "locked": {
-        "lastModified": 1705309234,
-        "narHash": "sha256-uNRRNRKmJyCRC/8y1RqBkqWBLM034y4qN7EprSdmgyA=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "1ef2e671c3b0c19053962c07dbda38332dcebf26",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "type": "github"
-      }
-    },
     "nixpkgs": {
       "locked": {
         "lastModified": 1722087241,
@@ -66,11 +48,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1706487304,
-        "narHash": "sha256-LE8lVX28MV2jWJsidW13D2qrHU/RUUONendL2Q/WlJg=",
+        "lastModified": 1718428119,
+        "narHash": "sha256-WdWDpNaq6u1IPtxtYHHWpl5BmabtpmLnMAx0RdJ/vo8=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "90f456026d284c22b3e3497be980b2e47d0b28ac",
+        "rev": "e6cea36f83499eb4e9cd184c8a8e823296b50ad5",
         "type": "github"
       },
       "original": {
@@ -89,35 +71,19 @@
     },
     "rust-overlay": {
       "inputs": {
-        "flake-utils": "flake-utils",
         "nixpkgs": "nixpkgs_2"
       },
       "locked": {
-        "lastModified": 1714097613,
-        "narHash": "sha256-044xbpBszupqN3nl/CGOCJtTQ4O6Aca81mJpX45i8/I=",
+        "lastModified": 1722219664,
+        "narHash": "sha256-xMOJ+HW4yj6e69PvieohUJ3dBSdgCfvI0nnCEe6/yVc=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "2a42c742ab04b61d9b2f1edf392842cf9f27ebfd",
+        "rev": "a6fbda5d9a14fb5f7c69b8489d24afeb349c7bb4",
         "type": "github"
       },
       "original": {
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "type": "github"
-      }
-    },
-    "systems": {
-      "locked": {
-        "lastModified": 1681028828,
-        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
-        "owner": "nix-systems",
-        "repo": "default",
-        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-systems",
-        "repo": "default",
         "type": "github"
       }
     }

--- a/flake.nix
+++ b/flake.nix
@@ -1,6 +1,6 @@
 {
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs/nixos-23.11";
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-24.05";
     flake-parts.url = "github:hercules-ci/flake-parts";
     rust-overlay.url = "github:oxalica/rust-overlay";
   };

--- a/rustls-platform-verifier/src/tests/verification_real_world/mod.rs
+++ b/rustls-platform-verifier/src/tests/verification_real_world/mod.rs
@@ -14,13 +14,13 @@
 //! effort  
 //!
 //! * If these certificates are ever revoked then it is possible that, even if
-//! with the measures mentioned in the next paragraphs, the operating system
-//! might learn of the revocation externally and cause the tests to fail.
+//!   with the measures mentioned in the next paragraphs, the operating system
+//!   might learn of the revocation externally and cause the tests to fail.
 //!
 //! * Some operating systems, Windows in particular, download the set of
-//! trusted roots dynamically as-needed. If there is a failure during that
-//! fetching then the trust anchors for these certificates might not be
-//! trusted by the operating system's root store.
+//!   trusted roots dynamically as-needed. If there is a failure during that
+//!   fetching then the trust anchors for these certificates might not be
+//!   trusted by the operating system's root store.
 //!
 //! XXX: These tests should be using a stapled OCSP responses so that the
 //! (operating-system-based) verifier doesn't try to fetch an OCSP

--- a/rustls-platform-verifier/src/verification/android.rs
+++ b/rustls-platform-verifier/src/verification/android.rs
@@ -190,7 +190,7 @@ impl Verifier {
                     VERIFIER_CALL,
                     &[
                         JValue::from(*cx.application_context()),
-                        JValue::from(env.new_string(&server_name.to_str())?),
+                        JValue::from(env.new_string(server_name.to_str())?),
                         JValue::from(env.new_string(AUTH_TYPE)?),
                         JValue::from(JObject::from(allowed_ekus)),
                         JValue::from(ocsp_response),


### PR DESCRIPTION
* Bumps Nix flake inputs
* Fixes two clippy findings breaking CI on the clippy stable task since the last stable update.
* Fixes a couple typos noticed in `RELEASING.md` when preparing https://github.com/rustls/rustls-platform-verifier/pull/114