### PR TITLE
ci: disable dependabot cargo updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,14 +1,5 @@
 version: 2
 updates:
-- package-ecosystem: cargo
-  directory: "/"
-  schedule:
-    interval: weekly
-  open-pull-requests-limit: 5
-  groups:
-    crates-io:
-      patterns:
-        - "*"
 - package-ecosystem: github-actions
   directory: "/"
   schedule:


### PR DESCRIPTION
Until we have a better sense of how to handle the update PRs it produces let's turn this off for now. I think I was premature in enabling it. Inspired by [discussion in this PR thread](https://github.com/rustls/rustls-platform-verifier/pull/119#discussion_r1704544595).
