### PR TITLE
fix: wasm compilation errors

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,12 +67,11 @@ jobs:
           rustup target add x86_64-apple-ios
           cargo clippy-ci --target x86_64-apple-ios
 
-      # TODO: Should WASM be checked in CI? If so, with what tooling?
-      # - name: Clippy (WASM)
-      #   if: matrix.os == 'ubuntu-latest'
-      #   run: |
-      #     rustup target add wasm32-unknown-unknown
-      #     cargo clippy-ci --target wasm32-unknown-unknown
+      - name: Clippy (WASM)
+        if: matrix.os == 'ubuntu-latest'
+        run: |
+          rustup target add wasm32-unknown-unknown
+          cargo clippy-ci --target wasm32-unknown-unknown
 
   clippy-msrv:
     name: Clippy (MSRV)
@@ -112,7 +111,11 @@ jobs:
           rustup target add x86_64-apple-ios
           cargo clippy-msrv-ci --target x86_64-apple-ios
 
-      # TODO: Consider WASM. See note on "clippy" job.
+      - name: Clippy (WASM)
+        if: matrix.os == 'ubuntu-latest'
+        run: |
+          rustup target add wasm32-unknown-unknown
+          cargo clippy-msrv-ci --target wasm32-unknown-unknown
 
   test:
     name: Test
@@ -186,7 +189,7 @@ jobs:
             /Users/runner/work/rustls-platform-verifier/rustls-platform-verifier/android/rustls-platform-verifier/build/outputs/androidTest-results/connected/test-result.pb
 
   # TODO: Test iOS in CI too.
-     
+
   test-freebsd:
     name: Test (FreeBSD)
     runs-on: ubuntu-latest
@@ -222,7 +225,7 @@ jobs:
           components: rustfmt
 
       - run: cargo fmt --all -- --check
-  
+
   android_fmt:
     name: Ktlint
     runs-on: ubuntu-latest
@@ -243,7 +246,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           persist-credentials: false
-      
+
       - name: Verify release artifact
         run: ./ci/verify_android_release.sh
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -48,6 +48,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
+name = "bumpalo"
+version = "3.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "79296716171880943b8470b5f8d03aa55eb2e645a4874bdbb28adb49162e012c"
+
+[[package]]
 name = "bytes"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -117,8 +123,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fe9006bed769170c11f845cf00c7c1e9092aeb3f268e007c3e760ac68008070f"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "wasi",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -140,6 +148,15 @@ name = "jni-sys"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8eaf4bc02d17cbdd7ff4c7438cafcdf7fb9a4613313ad11b4f8fefe7d3fa0130"
+
+[[package]]
+name = "js-sys"
+version = "0.3.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29c15563dc2726973df627357ce0c9ddddbea194836909d655df6a75d2cf296d"
+dependencies = [
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "libc"
@@ -316,6 +333,7 @@ dependencies = [
  "jni",
  "log",
  "once_cell",
+ "ring",
  "rustls",
  "rustls-native-certs",
  "rustls-platform-verifier-android",
@@ -453,6 +471,60 @@ name = "wasi"
 version = "0.11.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
+
+[[package]]
+name = "wasm-bindgen"
+version = "0.2.92"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4be2531df63900aeb2bca0daaaddec08491ee64ceecbee5076636a3b026795a8"
+dependencies = [
+ "cfg-if",
+ "wasm-bindgen-macro",
+]
+
+[[package]]
+name = "wasm-bindgen-backend"
+version = "0.2.92"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "614d787b966d3989fa7bb98a654e369c762374fd3213d212cfc0251257e747da"
+dependencies = [
+ "bumpalo",
+ "log",
+ "once_cell",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.92"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1f8823de937b71b9460c0c34e25f3da88250760bec0ebac694b49997550d726"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.92"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e94f17b526d0a461a191c78ea52bbce64071ed5c04c9ffe424dcb38f74171bb7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-backend",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.92"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af190c94f2773fdb3729c55b007a722abb5384da03bc0986df4c289bf5567e96"
 
 [[package]]
 name = "webpki-roots"

--- a/rustls-platform-verifier/Cargo.toml
+++ b/rustls-platform-verifier/Cargo.toml
@@ -47,6 +47,7 @@ android_logger = { version = "0.13", optional = true } # Only used during testin
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 webpki-roots = "0.26"
+webpki = { package = "rustls-webpki", version = "0.102", default-features = false }
 
 # BSD targets require webpki-roots for the real-world verification tests.
 [target.'cfg(target_os = "freebsd")'.dev-dependencies]

--- a/rustls-platform-verifier/Cargo.toml
+++ b/rustls-platform-verifier/Cargo.toml
@@ -48,8 +48,6 @@ android_logger = { version = "0.13", optional = true } # Only used during testin
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 webpki-roots = "0.26"
 webpki = { package = "rustls-webpki", version = "0.102", default-features = false }
-
-[target.'cfg(target_arch = "wasm32")'.dev-dependencies]
 ring = { version = "0.17.7", features = ["wasm32_unknown_unknown_js"] }
 
 # BSD targets require webpki-roots for the real-world verification tests.

--- a/rustls-platform-verifier/Cargo.toml
+++ b/rustls-platform-verifier/Cargo.toml
@@ -49,6 +49,9 @@ android_logger = { version = "0.13", optional = true } # Only used during testin
 webpki-roots = "0.26"
 webpki = { package = "rustls-webpki", version = "0.102", default-features = false }
 
+[target.'cfg(target_arch = "wasm32")'.dev-dependencies]
+ring = { version = "0.17.7", features = ["wasm32_unknown_unknown_js"] }
+
 # BSD targets require webpki-roots for the real-world verification tests.
 [target.'cfg(target_os = "freebsd")'.dev-dependencies]
 webpki-roots = "0.26"

--- a/rustls-platform-verifier/src/verification/others.rs
+++ b/rustls-platform-verifier/src/verification/others.rs
@@ -154,13 +154,7 @@ impl Verifier {
 
         #[cfg(target_arch = "wasm32")]
         {
-            root_store.add_trust_anchors(webpki_roots::TLS_SERVER_ROOTS.iter().map(|root| {
-                rustls::OwnedTrustAnchor::from_subject_spki_name_constraints(
-                    root.subject,
-                    root.spki,
-                    root.name_constraints,
-                )
-            }));
+            root_store.extend(webpki_roots::TLS_SERVER_ROOTS.iter().cloned());
         };
 
         WebPkiServerVerifier::builder_with_provider(


### PR DESCRIPTION
Thanks for the awesome library!

This PR aims to resolve compilation errors when targeting wasm32, which were caused by breaking changes to the [RootCertStore](https://docs.rs/rustls/latest/rustls/struct.RootCertStore.html) interface that needed to be migrated in the conditionally compiled code.

Additionally, I've added a couple Clippy build steps to the CI workflow to try to prevent the code targeting WASM from becoming stale over time as rustls continues to evolve.