### PR TITLE
Fix UB in Windows verifier EKU handling 

### DIFF
--- a/rustls-platform-verifier/src/verification/mod.rs
+++ b/rustls-platform-verifier/src/verification/mod.rs
@@ -82,8 +82,11 @@ fn invalid_certificate(reason: impl Into<String>) -> rustls::Error {
 /// - id-kp-serverAuth
 // TODO: Chromium also allows for `OID_ANY_EKU` on Android.
 #[cfg(target_os = "windows")]
+// XXX: Windows requires that we NUL terminate EKU strings and we want to make sure that only the
+// data part of the `&str` pointer (using `.as_ptr()`), not all of its metadata.
+// This can be cleaned up when our MSRV is increased to 1.77 and C-string literals are available.
+// See https://github.com/rustls/rustls-platform-verifier/issues/126#issuecomment-2306232794.
 const ALLOWED_EKUS: &[*mut u8] = &["1.3.6.1.5.5.7.3.1\0".as_ptr() as *mut u8];
-
 #[cfg(target_os = "android")]
 pub const ALLOWED_EKUS: &[&str] = &["1.3.6.1.5.5.7.3.1"];
 

--- a/rustls-platform-verifier/src/verification/mod.rs
+++ b/rustls-platform-verifier/src/verification/mod.rs
@@ -74,7 +74,6 @@ fn invalid_certificate(reason: impl Into<String>) -> rustls::Error {
     )))
 }
 
-#[cfg(any(windows, target_os = "android"))]
 /// List of EKUs that one or more of that *must* be in the end-entity certificate.
 ///
 /// Legacy server-gated crypto OIDs are assumed to no longer be in use.
@@ -82,6 +81,10 @@ fn invalid_certificate(reason: impl Into<String>) -> rustls::Error {
 /// Currently supported:
 /// - id-kp-serverAuth
 // TODO: Chromium also allows for `OID_ANY_EKU` on Android.
+#[cfg(target_os = "windows")]
+const ALLOWED_EKUS: &[*mut u8] = &["1.3.6.1.5.5.7.3.1\0".as_ptr() as *mut u8];
+
+#[cfg(target_os = "android")]
 pub const ALLOWED_EKUS: &[&str] = &["1.3.6.1.5.5.7.3.1"];
 
 impl Verifier {


### PR DESCRIPTION
This PR implements two fixes in the Windows verifier to fix UB and future-UB:
- Properly `NULL`-terminate the EKU strings we pass in.
- Only pass in a thin pointer containing the string data to Windows, not the slice's fat pointer.

See the linked issue for a more detailed analysis if your curious why this was never problematic before.

Closes #126 