### PR TITLE
Add new with extra roots on windows

### DIFF
--- a/rustls-platform-verifier/src/tests/verification_mock/mod.rs
+++ b/rustls-platform-verifier/src/tests/verification_mock/mod.rs
@@ -116,7 +116,8 @@ pub(super) fn verification_without_mock_root() {
             .iter()
             .cloned()
             .collect(),
-    );
+    )
+    .unwrap();
 
     #[cfg(not(target_os = "freebsd"))]
     let verifier = Verifier::new();
@@ -337,7 +338,7 @@ fn test_with_mock_root<E: std::error::Error + PartialEq + 'static>(
     let verifier = match root_src {
         Roots::OnlyExtra => Verifier::new_with_fake_root(ROOT1), // TODO: time
         #[cfg(not(target_os = "android"))]
-        Roots::ExtraAndPlatform => Verifier::new_with_extra_roots(vec![ROOT1.into()]),
+        Roots::ExtraAndPlatform => Verifier::new_with_extra_roots(vec![ROOT1.into()]).unwrap(),
     };
     let mut chain = test_case
         .chain

--- a/rustls-platform-verifier/src/tests/verification_mock/mod.rs
+++ b/rustls-platform-verifier/src/tests/verification_mock/mod.rs
@@ -43,7 +43,7 @@ macro_rules! mock_root_test_cases {
                 }
 
                 paste::paste!{
-                    #[cfg(all($target, not(windows), not(target_os = "android")))]
+                    #[cfg(all($target, not(target_os = "android")))]
                     #[test]
                     pub fn [<$name _extra>](){
                         super::[<$name _extra>]()
@@ -60,7 +60,7 @@ macro_rules! mock_root_test_cases {
                 $name,
 
                 paste::paste!{
-                    #[cfg(all($target, not(windows), not(target_os = "android")))]
+                    #[cfg(all($target, not(target_os = "android")))]
                     [<$name _extra>]
                 }
 
@@ -77,7 +77,7 @@ macro_rules! mock_root_test_cases {
             }
 
             paste::paste!{
-                #[cfg(all($target, not(windows), not(target_os = "android")))]
+                #[cfg(all($target, not(target_os = "android")))]
                 pub(super) fn [<$name _extra>]() {
                     test_with_mock_root(&$test_case, Roots::ExtraAndPlatform);
                 }
@@ -336,7 +336,7 @@ fn test_with_mock_root<E: std::error::Error + PartialEq + 'static>(
 
     let verifier = match root_src {
         Roots::OnlyExtra => Verifier::new_with_fake_root(ROOT1), // TODO: time
-        #[cfg(all(unix, not(target_os = "android")))]
+        #[cfg(not(target_os = "android"))]
         Roots::ExtraAndPlatform => Verifier::new_with_extra_roots(vec![ROOT1.into()]),
     };
     let mut chain = test_case
@@ -379,6 +379,6 @@ enum Roots {
     /// Test with loading the extra roots and the platform trust store.
     ///
     /// Right now, not all platforms are supported.
-    #[cfg(all(unix, not(target_os = "android")))]
+    #[cfg(not(target_os = "android"))]
     ExtraAndPlatform,
 }

--- a/rustls-platform-verifier/src/tests/verification_real_world/mod.rs
+++ b/rustls-platform-verifier/src/tests/verification_real_world/mod.rs
@@ -133,7 +133,8 @@ fn real_world_test<E: std::error::Error>(test_case: &TestCase<E>) {
             .iter()
             .cloned()
             .collect(),
-    );
+    )
+    .unwrap();
 
     #[cfg(not(target_os = "freebsd"))]
     let verifier = Verifier::new();

--- a/rustls-platform-verifier/src/verification/others.rs
+++ b/rustls-platform-verifier/src/verification/others.rs
@@ -53,8 +53,10 @@ impl Verifier {
     /// Creates a new verifier whose certificate validation is provided by
     /// WebPKI, using root certificates provided by the platform and augmented by
     /// the provided extra root certificates.
-    pub fn new_with_extra_roots(roots: Vec<pki_types::CertificateDer<'static>>) -> Self {
-        Self {
+    pub fn new_with_extra_roots(
+        roots: Vec<pki_types::CertificateDer<'static>>,
+    ) -> Result<Self, TlsError> {
+        Ok(Self {
             inner: OnceCell::new(),
             extra_roots: roots
                 .into_iter()
@@ -66,7 +68,7 @@ impl Verifier {
             #[cfg(any(test, feature = "ffi-testing", feature = "dbg"))]
             test_only_root_ca_override: None,
             crypto_provider: OnceCell::new(),
-        }
+        })
     }
 
     /// Creates a test-only TLS certificate verifier which trusts our fake root CA cert.

--- a/rustls-platform-verifier/src/verification/windows.rs
+++ b/rustls-platform-verifier/src/verification/windows.rs
@@ -136,7 +136,7 @@ impl CertChain {
         extra_params.pwszServerName = server_null_terminated.as_mut_ptr();
 
         let mut params = CERT_CHAIN_POLICY_PARA::zeroed_with_size();
-        // Ignore any errors when trying to obtain OCSP recovcation information.
+        // Ignore any errors when trying to obtain OCSP revocation information.
         // This is also done in OpenSSL, Secure Transport from Apple, etc.
         params.dwFlags = CERT_CHAIN_POLICY_IGNORE_ALL_REV_UNKNOWN_FLAGS;
         // `extra_params` outlives `params`.


### PR DESCRIPTION
Windows implementation of `new_with_extra_roots`, which have some problems for now as mentioned in https://github.com/rustls/rustls-platform-verifier/pull/133#issuecomment-2315871410.
Note that it's based on top of https://github.com/rustls/rustls-platform-verifier/pull/133 to benefit the tests defined here.

Partially Fix https://github.com/rustls/rustls-platform-verifier/issues/58