### PR TITLE
Fix and defend wasm code using wasi platform

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,12 +67,11 @@ jobs:
           rustup target add x86_64-apple-ios
           cargo clippy-ci --target x86_64-apple-ios
 
-      # TODO: Should WASM be checked in CI? If so, with what tooling?
-      # - name: Clippy (WASM)
-      #   if: matrix.os == 'ubuntu-latest'
-      #   run: |
-      #     rustup target add wasm32-unknown-unknown
-      #     cargo clippy-ci --target wasm32-unknown-unknown
+      - name: Clippy (WASM)
+        if: matrix.os == 'ubuntu-latest'
+        run: |
+          rustup target add wasm32-wasip1
+          cargo clippy-ci --target wasm32-wasip1
 
   clippy-msrv:
     name: Clippy (MSRV)

--- a/rustls-platform-verifier/Cargo.toml
+++ b/rustls-platform-verifier/Cargo.toml
@@ -47,6 +47,7 @@ android_logger = { version = "0.13", optional = true } # Only used during testin
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 webpki-roots = "0.26"
+webpki = { package = "rustls-webpki", version = "0.102", default-features = false }
 
 # BSD targets require webpki-roots for the real-world verification tests.
 [target.'cfg(target_os = "freebsd")'.dev-dependencies]

--- a/rustls-platform-verifier/src/verification/others.rs
+++ b/rustls-platform-verifier/src/verification/others.rs
@@ -154,13 +154,9 @@ impl Verifier {
 
         #[cfg(target_arch = "wasm32")]
         {
-            root_store.add_trust_anchors(webpki_roots::TLS_SERVER_ROOTS.iter().map(|root| {
-                rustls::OwnedTrustAnchor::from_subject_spki_name_constraints(
-                    root.subject,
-                    root.spki,
-                    root.name_constraints,
-                )
-            }));
+            root_store
+                .roots
+                .extend_from_slice(webpki_roots::TLS_SERVER_ROOTS);
         };
 
         WebPkiServerVerifier::builder_with_provider(


### PR DESCRIPTION
This avoids all the annoyance with the `wasm32-unknown-unknown` platform, and arguably wasi is more typical for a networked application.

This PR is a variation on #122.