### PR TITLE
ci: add cargo-semver-checks-action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -246,6 +246,18 @@ jobs:
       - name: Verify release artifact
         run: ./ci/verify_android_release.sh
 
+  semver:
+    name: Check semver compatibility
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - name: Check semver
+        uses: obi1kenobi/cargo-semver-checks-action@v2
+
   docs:
     name: Check for documentation errors
     runs-on: ubuntu-latest


### PR DESCRIPTION
We've used [cargo-semver-checks](https://github.com/obi1kenobi/cargo-semver-checks) with success in many other Rustls repos. It's not perfect but catches a variety of semver breaks that could be missed otherwise.