### PR TITLE
relax `new_with_extra_roots` API

### DIFF
--- a/rustls-platform-verifier/src/tests/verification_mock/mod.rs
+++ b/rustls-platform-verifier/src/tests/verification_mock/mod.rs
@@ -111,13 +111,9 @@ pub(super) fn verification_without_mock_root() {
     // runner fails to find any roots with openssl-probe we need to provide webpki-root-certs here
     // or the test will fail with the `OtherError` instead of the expected `CertificateError`.
     #[cfg(target_os = "freebsd")]
-    let verifier = Verifier::new_with_extra_roots(
-        webpki_root_certs::TLS_SERVER_ROOT_CERTS
-            .iter()
-            .cloned()
-            .collect(),
-    )
-    .unwrap();
+    let verifier =
+        Verifier::new_with_extra_roots(webpki_root_certs::TLS_SERVER_ROOT_CERTS.iter().cloned())
+            .unwrap();
 
     #[cfg(not(target_os = "freebsd"))]
     let verifier = Verifier::new();
@@ -338,7 +334,7 @@ fn test_with_mock_root<E: std::error::Error + PartialEq + 'static>(
     let verifier = match root_src {
         Roots::OnlyExtra => Verifier::new_with_fake_root(ROOT1), // TODO: time
         #[cfg(not(target_os = "android"))]
-        Roots::ExtraAndPlatform => Verifier::new_with_extra_roots(vec![ROOT1.into()]).unwrap(),
+        Roots::ExtraAndPlatform => Verifier::new_with_extra_roots([ROOT1.into()]).unwrap(),
     };
     let mut chain = test_case
         .chain

--- a/rustls-platform-verifier/src/tests/verification_real_world/mod.rs
+++ b/rustls-platform-verifier/src/tests/verification_real_world/mod.rs
@@ -128,13 +128,9 @@ fn real_world_test<E: std::error::Error>(test_case: &TestCase<E>) {
     // On BSD systems openssl-probe fails to find the system CA bundle,
     // so we must provide extra roots from webpki-root-cert.
     #[cfg(target_os = "freebsd")]
-    let verifier = Verifier::new_with_extra_roots(
-        webpki_root_certs::TLS_SERVER_ROOT_CERTS
-            .iter()
-            .cloned()
-            .collect(),
-    )
-    .unwrap();
+    let verifier =
+        Verifier::new_with_extra_roots(webpki_root_certs::TLS_SERVER_ROOT_CERTS.iter().cloned())
+            .unwrap();
 
     #[cfg(not(target_os = "freebsd"))]
     let verifier = Verifier::new();

--- a/rustls-platform-verifier/src/verification/apple.rs
+++ b/rustls-platform-verifier/src/verification/apple.rs
@@ -73,7 +73,7 @@ impl Verifier {
     ///
     /// See [Verifier::new] for the external requirements the verifier needs.
     pub fn new_with_extra_roots(
-        roots: Vec<pki_types::CertificateDer<'static>>,
+        roots: impl IntoIterator<Item = pki_types::CertificateDer<'static>>,
     ) -> Result<Self, TlsError> {
         let extra_roots = roots
             .into_iter()

--- a/rustls-platform-verifier/src/verification/others.rs
+++ b/rustls-platform-verifier/src/verification/others.rs
@@ -54,7 +54,7 @@ impl Verifier {
     /// WebPKI, using root certificates provided by the platform and augmented by
     /// the provided extra root certificates.
     pub fn new_with_extra_roots(
-        roots: Vec<pki_types::CertificateDer<'static>>,
+        roots: impl IntoIterator<Item = pki_types::CertificateDer<'static>>,
     ) -> Result<Self, TlsError> {
         Ok(Self {
             inner: OnceCell::new(),

--- a/rustls-platform-verifier/src/verification/windows.rs
+++ b/rustls-platform-verifier/src/verification/windows.rs
@@ -219,11 +219,11 @@ struct CertEngine {
 
 impl CertEngine {
     fn new_with_extra_roots(
-        roots: &[pki_types::CertificateDer<'static>],
+        roots: impl IntoIterator<Item = pki_types::CertificateDer<'static>>,
     ) -> Result<Self, TlsError> {
         let mut exclusive_store = CertificateStore::new()?;
         for root in roots {
-            exclusive_store.add_cert(root)?;
+            exclusive_store.add_cert(&root)?;
         }
 
         let mut config = CERT_CHAIN_ENGINE_CONFIG::zeroed_with_size();
@@ -516,9 +516,9 @@ impl Verifier {
     /// [`set_provider`][Verifier::set_provider]/[`with_provider`][Verifier::with_provider] or
     /// [`CryptoProvider::install_default`] before the verifier can be used.
     pub fn new_with_extra_roots(
-        roots: Vec<pki_types::CertificateDer<'static>>,
+        roots: impl IntoIterator<Item = pki_types::CertificateDer<'static>>,
     ) -> Result<Self, TlsError> {
-        let cert_engine = CertEngine::new_with_extra_roots(&roots)?;
+        let cert_engine = CertEngine::new_with_extra_roots(roots)?;
         Ok(Self {
             #[cfg(any(test, feature = "ffi-testing", feature = "dbg"))]
             test_only_root_ca_override: None,


### PR DESCRIPTION
This PR relax the `new_with_extra_roots` API, as discussed in https://github.com/rustls/rustls-platform-verifier/issues/58#issuecomment-2410160306