### PR TITLE
Bump Java CI testing version from 11 to 17

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -155,7 +155,7 @@ jobs:
           java-version: '17'
 
       - name: Run Android tests
-        uses: reactivecircus/android-emulator-runner@f0d1ed2dcad93c7479e8b2f2226c83af54494915 # 2.32.0
+        uses: reactivecircus/android-emulator-runner@62dbb605bba737720e10b196cb4220d374026a6d # 2.33.0
         with:
           api-level: 28 # Android 9, Pie.
           arch: x86_64

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -152,7 +152,7 @@ jobs:
         uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
-          java-version: '11'
+          java-version: '17'
 
       - name: Run Android tests
         uses: reactivecircus/android-emulator-runner@f0d1ed2dcad93c7479e8b2f2226c83af54494915 # 2.32.0


### PR DESCRIPTION
This fixes CI on `main` after GitHub bumped the default Ubuntu runner version, including the default Android SDK tooling which is now ahead of the Java version we setup in CI for compiling and running Android tests. 

The choice of Java 17 was to match the new class version minimum reported as a CI error before. The `61.0` version corresponds to 17 based on [this table](https://javaalmanac.io/bytecode/versions/).