### PR TITLE
Run tests on iOS using Mac Catalyst and expand Apple platforms

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,16 @@ jobs:
           rustup component add rust-src --toolchain nightly-aarch64-apple-darwin
           cargo +nightly clippy -Zbuild-std --target aarch64-apple-tvos
 
+      - name: Clippy (watchOS)
+        run: |
+          rustup component add rust-src --toolchain nightly-aarch64-apple-darwin
+          cargo +nightly clippy -Zbuild-std --target aarch64-apple-watchos
+
+      - name: Clippy (visionOS)
+        run: |
+          rustup component add rust-src --toolchain nightly-aarch64-apple-darwin
+          cargo +nightly clippy -Zbuild-std --target aarch64-apple-visionos
+
   clippy:
     name: Clippy (stable)
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -194,7 +194,15 @@ jobs:
             ./android/emulator.log
             /Users/runner/work/rustls-platform-verifier/rustls-platform-verifier/android/rustls-platform-verifier/build/outputs/androidTest-results/connected/test-result.pb
 
-  # TODO: Test iOS in CI too.
+  test_ios:
+    name: "Test iOS (Catalyst)"
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Run iOS tests
+        run: |
+          rustup target add aarch64-apple-ios-macabi
+          cargo test --target aarch64-apple-ios-macabi
 
   test-freebsd:
     name: Test (FreeBSD)

--- a/rustls-platform-verifier/Cargo.toml
+++ b/rustls-platform-verifier/Cargo.toml
@@ -36,7 +36,7 @@ jni = { version = "0.19", default-features = false, optional = true } # Only use
 once_cell = "1.9"
 paste = { version = "1.0", default-features = false, optional = true } # Only used when `ffi-testing` feature is enabled
 
-[target.'cfg(all(unix, not(target_os = "android"), not(target_os = "macos"), not(target_os = "ios"), not(target_os = "tvos"), not(target_arch = "wasm32")))'.dependencies]
+[target.'cfg(all(unix, not(target_os = "android"), not(target_vendor = "apple"), not(target_arch = "wasm32")))'.dependencies]
 rustls-native-certs = "0.7"
 webpki = { package = "rustls-webpki", version = "0.102", default-features = false }
 
@@ -54,7 +54,7 @@ webpki-root-certs = "0.26"
 [target.'cfg(target_os = "freebsd")'.dev-dependencies]
 webpki-root-certs = "0.26"
 
-[target.'cfg(any(target_os = "macos", target_os = "ios", target_os = "tvos"))'.dependencies]
+[target.'cfg(any(target_vendor = "apple"))'.dependencies]
 core-foundation = "0.9"
 core-foundation-sys = "0.8"
 security-framework = { version = "2.10", features = ["OSX_10_14"] }

--- a/rustls-platform-verifier/src/tests/ffi.rs
+++ b/rustls-platform-verifier/src/tests/ffi.rs
@@ -150,7 +150,7 @@ mod dummy {
         #[cfg(any(
             windows,
             target_os = "android",
-            target_os = "macos",
+            target_vendor = "apple",
             target_os = "linux"
         ))]
         let _ = tests::verification_mock::ALL_TEST_CASES;

--- a/rustls-platform-verifier/src/tests/verification_mock/mod.rs
+++ b/rustls-platform-verifier/src/tests/verification_mock/mod.rs
@@ -16,7 +16,10 @@
 #![cfg(all(
     any(windows, unix, target_os = "android"),
     not(target_os = "ios"),
-    not(target_os = "tvos")
+    // These OSes require a simulator runtime and bundle.
+    not(target_os = "tvos"),
+    not(target_os = "watchos"),
+    not(target_os = "visionos")
 ))]
 
 use super::TestCase;
@@ -209,7 +212,7 @@ mock_root_test_cases! {
     // Check that self-signed certificates, which may or may not be revokved, do not return any
     // kind of revocation error. It is expected that non-public certificates without revocation information
     // have no revocation checking performed across platforms.
-    revoked_dns [ any(windows, target_os = "android", target_os = "macos") ] => TestCase {
+    revoked_dns [ any(windows, target_os = "android", target_vendor = "apple") ] => TestCase {
         reference_id: EXAMPLE_COM,
         chain: &[include_bytes!("root1-int1-ee_example.com-revoked.crt"), ROOT1_INT1],
         stapled_ocsp: None,
@@ -217,7 +220,7 @@ mock_root_test_cases! {
         expected_result: Ok(()),
         other_error: no_error!(),
     },
-    stapled_revoked_dns [ any(windows, target_os = "android", target_os = "macos") ] => TestCase {
+    stapled_revoked_dns [ any(windows, target_os = "android", target_vendor = "apple") ] => TestCase {
         reference_id: EXAMPLE_COM,
         chain: &[include_bytes!("root1-int1-ee_example.com-revoked.crt"), ROOT1_INT1],
         stapled_ocsp: Some(include_bytes!("root1-int1-ee_example.com-revoked.ocsp")),
@@ -225,7 +228,7 @@ mock_root_test_cases! {
         expected_result: Err(TlsError::InvalidCertificate(CertificateError::Revoked)),
         other_error: no_error!(),
     },
-    stapled_revoked_ipv4 [ any(windows, target_os = "android", target_os = "macos") ] => TestCase {
+    stapled_revoked_ipv4 [ any(windows, target_os = "android", target_vendor = "apple") ] => TestCase {
         reference_id: LOCALHOST_IPV4,
         chain: &[include_bytes!("root1-int1-ee_127.0.0.1-revoked.crt"), ROOT1_INT1],
         stapled_ocsp: Some(include_bytes!("root1-int1-ee_127.0.0.1-revoked.ocsp")),
@@ -233,7 +236,7 @@ mock_root_test_cases! {
         expected_result: Err(TlsError::InvalidCertificate(CertificateError::Revoked)),
         other_error: no_error!(),
     },
-    stapled_revoked_ipv6 [ any(windows, target_os = "android", target_os = "macos") ] => TestCase {
+    stapled_revoked_ipv6 [ any(windows, target_os = "android", target_vendor = "apple") ] => TestCase {
         reference_id: LOCALHOST_IPV6,
         chain: &[include_bytes!("root1-int1-ee_1-revoked.crt"), ROOT1_INT1],
         stapled_ocsp: Some(include_bytes!("root1-int1-ee_1-revoked.ocsp")),

--- a/rustls-platform-verifier/src/tests/verification_mock/mod.rs
+++ b/rustls-platform-verifier/src/tests/verification_mock/mod.rs
@@ -15,7 +15,6 @@
 
 #![cfg(all(
     any(windows, unix, target_os = "android"),
-    not(target_os = "ios"),
     // These OSes require a simulator runtime and bundle.
     not(target_os = "tvos"),
     not(target_os = "watchos"),

--- a/rustls-platform-verifier/src/verification/mod.rs
+++ b/rustls-platform-verifier/src/verification/mod.rs
@@ -4,25 +4,21 @@ use std::sync::Arc;
 #[cfg(all(
     any(unix, target_arch = "wasm32"),
     not(target_os = "android"),
-    not(target_os = "macos"),
-    not(target_os = "ios"),
-    not(target_os = "tvos")
+    not(target_vendor = "apple"),
 ))]
 mod others;
 
 #[cfg(all(
     any(unix, target_arch = "wasm32"),
     not(target_os = "android"),
-    not(target_os = "macos"),
-    not(target_os = "ios"),
-    not(target_os = "tvos")
+    not(target_vendor = "apple"),
 ))]
 pub use others::Verifier;
 
-#[cfg(any(target_os = "macos", target_os = "ios", target_os = "tvos"))]
+#[cfg(target_vendor = "apple")]
 mod apple;
 
-#[cfg(any(target_os = "macos", target_os = "ios", target_os = "tvos"))]
+#[cfg(target_vendor = "apple")]
 pub use apple::Verifier;
 
 #[cfg(target_os = "android")]
@@ -67,7 +63,7 @@ fn log_server_cert(_end_entity: &rustls::pki_types::CertificateDer<'_>) {
 
 // Unknown certificate error shorthand. Used when we need to construct an "Other" certificate
 // error with a platform specific error message.
-#[cfg(any(windows, target_os = "macos", target_os = "ios", target_os = "tvos"))]
+#[cfg(any(windows, target_vendor = "apple"))]
 fn invalid_certificate(reason: impl Into<String>) -> rustls::Error {
     rustls::Error::InvalidCertificate(rustls::CertificateError::Other(rustls::OtherError(
         Arc::from(Box::from(reason.into())),

--- a/rustls-platform-verifier/src/verification/others.rs
+++ b/rustls-platform-verifier/src/verification/others.rs
@@ -124,9 +124,7 @@ impl Verifier {
         #[cfg(all(
             unix,
             not(target_os = "android"),
-            not(target_os = "macos"),
-            not(target_os = "ios"),
-            not(target_os = "tvos"),
+            not(target_vendor = "apple"),
             not(target_arch = "wasm32"),
         ))]
         match rustls_native_certs::load_native_certs() {


### PR DESCRIPTION
This PR accomplishes two things:
- Compiling and running all of the tests on an iOS target, by utilizing Catalyst targets as pointed out in [today's 1.82.0 release notes](https://blog.rust-lang.org/2024/10/17/Rust-1.82.0.html). 
    - This is not quite as complete as if we ran these tests in a full simulator, but the environment isn't going to be that different in our use case where we are solely calling `Security.framework` functions. Even in the simulator, a lot of frameworks and kernel functions come "from the macOS host" anyway.
- Expanding the Apple platforms that `rustls-platform-verifier` can be compiled for to all available ones today.
    - AFAICT, all of the `Security.framework` functions we call are available everywhere and have no special OS constraints. All of them make sense to support as well:
    - visionOS is very similar to iOS and has the same networking API availability, etc.
    - watchOS has some network API constraints which restrict what you could perform TLS over, but you could still bring your own transport encryption stack as [per the requirement documentation](https://developer.apple.com/documentation/technotes/tn3135-low-level-networking-on-watchos).

Closes https://github.com/rustls/rustls-platform-verifier/issues/4 (unless anyone thinks we need the simulator explicitly)