### PR TITLE
ci: add some missing persist-credentials

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -147,6 +147,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       # Turn on Linux KVM features/support for faster Android emulation.
       # References:
@@ -199,6 +201,8 @@ jobs:
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - name: Run iOS tests
         run: |
           rustup target add aarch64-apple-ios-macabi
@@ -209,6 +213,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - name: test on freebsd
         uses: vmactions/freebsd-vm@v1
         # Settings adopted from https://github.com/quinn-rs/quinn


### PR DESCRIPTION
Most of the checkout action usages in `ci.yml` already specified `persist-credentials: false`, but a few were missing it. This [is flagged](https://woodruffw.github.io/zizmor/audits/#artipacked) when running Zizmor 0.7.0 on the repo's CI config. As mentioned in the description of this finding:

> By default, using [actions/checkout](https://github.com/actions/checkout) causes a credential to be persisted in the checked-out repo's .git/config, so that subsequent git operations can be authenticated.
> 
> Subsequent steps may accidentally publicly persist .git/config, e.g. by including it in a publicly accessible artifact via [actions/upload-artifact](https://github.com/actions/upload-artifact).
> 
> However, even without this, persisting the credential in the .git/config is non-ideal unless actually needed.

We don't need it, so turn it off consistently :-)