### PR TITLE
Update the crate version in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ This means that it has received lots of exposure to edge cases and has real-worl
 ## Installation and setup
 On most platforms, no setup should be required beyond adding the dependency via `cargo`:
 ```toml
-rustls-platform-verifier = "0.3"
+rustls-platform-verifier = "0.5"
 ```
 
 To get a rustls `ClientConfig` configured to use the platform verifier use:


### PR DESCRIPTION
The examples in README can not be compiled because `ConfigVerifierExt` and `BuilderVerifierExt` don't exist in v0.3.
It should be updated to the latest version.
