### PR TITLE
Allow modern range of windows-sys versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,6 +83,14 @@ jobs:
           rustup target add wasm32-wasip1
           cargo clippy-ci --target wasm32-wasip1
 
+      # Update any flexible dependencies that may have SemVer applicable changes
+      # to ensure the project keeps building with the whole version range. This is:
+      # - windows-sys 0.52, which `rustls-platform-verifier` also should accept at 0.59.
+      - name: Clippy (dependency version checks)
+        run: |
+          cargo update -p windows-sys@0.52.0
+          cargo clippy-ci
+
   clippy-msrv:
     name: Clippy (MSRV)
     runs-on: ${{ matrix.os }}

--- a/rustls-platform-verifier/Cargo.toml
+++ b/rustls-platform-verifier/Cargo.toml
@@ -61,7 +61,7 @@ security-framework = { version = "3", features = ["OSX_10_14"] }
 security-framework-sys = { version = "2.10", features = ["OSX_10_14"] }
 
 [target.'cfg(windows)'.dependencies]
-windows-sys = { version = "0.52", default-features = false, features = ["Win32_Foundation", "Win32_Security_Cryptography"] }
+windows-sys = { version = ">=0.52.0, <0.60.0", default-features = false, features = ["Win32_Foundation", "Win32_Security_Cryptography"] }
 
 [dev-dependencies]
 rustls = { version = "0.23", default-features = false, features = ["ring"] }


### PR DESCRIPTION
This PR is based off my past work (and all of its referenced prior art) in https://github.com/1Password/arboard/pull/176/. The goal of this PR is to allow downstream users more flexibility in what version(s) of `windows-sys` cargo resolves into their lockfile.

By allowing two versions in the range, users have a higher chance of being able to only build one version and we appease both the users who want to keep their dependencies stable while not holding back the wider ecosystem and users who want to be on the latest versions all the time.

These changes also include a new CI task to ensure that nothing added to `windows.rs` runs into compatibility issues with `windows-sys` 0.59 (or any future versions we may add).