### PR TITLE
Remove signature list failure case in other Verifier

### DIFF
--- a/rustls-platform-verifier/src/verification/android.rs
+++ b/rustls-platform-verifier/src/verification/android.rs
@@ -235,8 +235,7 @@ impl Verifier {
                 }
             }
             Err(e) => Err(TlsError::General(format!(
-                "failed to call native verifier: {:?}",
-                e
+                "failed to call native verifier: {e:?}",
             ))),
         }
     }

--- a/rustls-platform-verifier/src/verification/apple.rs
+++ b/rustls-platform-verifier/src/verification/apple.rs
@@ -234,7 +234,7 @@ impl Verifier {
             })
             // Fallback to an error containing the description and specific error code so that
             // the exact error cause can be looked up easily.
-            .unwrap_or_else(|_| invalid_certificate(format!("{}: {}", trust_error, err_code)));
+            .unwrap_or_else(|_| invalid_certificate(format!("{trust_error}: {err_code}")));
 
         Err(err)
     }

--- a/rustls-platform-verifier/src/verification/others.rs
+++ b/rustls-platform-verifier/src/verification/others.rs
@@ -208,10 +208,13 @@ impl ServerCertVerifier for Verifier {
     }
 
     fn supported_verify_schemes(&self) -> Vec<SignatureScheme> {
-        match self.get_or_init_verifier() {
-            Ok(v) => v.supported_verify_schemes(),
-            Err(_) => Vec::default(),
-        }
+        // XXX: Don't go through `self.verifier` here: It introduces extra failure
+        // cases and is strictly unneeded because `get_provider` is the same provider and
+        // set of algorithms passed into the wrapped `WebPkiServerVerifier`. Given this,
+        // the list of schemes are identical.
+        self.get_provider()
+            .signature_verification_algorithms
+            .supported_schemes()
     }
 }
 


### PR DESCRIPTION
This PR attempts to improve the debugability of the Linux/BSD `others` `Verifier` implementation (ref https://github.com/rust-lang/rustup/issues/4305) by separating the crypto provider's logic from the actual `WebPkiServerVerifier` that needs instantiated and wrapped.

Instead of having a Verifier construction failure in the path of obtaining the crypto provider's signature list, obtain the list of signatures directly from the provider instead like on the other platforms. 

This makes failure case debugging consistent across the different platforms the platform verifier supports and just makes debugging failures with the `others` verifier easier too.

cc @djc 