### PR TITLE
Use CRL by default instead of OCSP on android

### DIFF
--- a/android/rustls-platform-verifier/src/main/java/org/rustls/platformverifier/CertificateVerifier.kt
+++ b/android/rustls-platform-verifier/src/main/java/org/rustls/platformverifier/CertificateVerifier.kt
@@ -330,7 +330,9 @@ internal object CertificateVerifier {
 
             revocationChecker.options = EnumSet.of(
                 PKIXRevocationChecker.Option.SOFT_FAIL,
-                PKIXRevocationChecker.Option.ONLY_END_ENTITY
+                PKIXRevocationChecker.Option.ONLY_END_ENTITY,
+                PKIXRevocationChecker.Option.PREFER_CRLS,
+                PKIXRevocationChecker.Option.NO_FALLBACK
             )
 
             // Use the OCSP data `rustls` provided, if present.


### PR DESCRIPTION
Hi, I have a certificate signed by let's encrypt, which only has a CRL extension but not an OCSP one, as for the _let's encrypt_ [new policy](https://letsencrypt.org/2024/12/05/ending-ocsp/). 

On the _rustls-platform-verifier_ documentation on **Android**, from my understanding, it says that if there is not a stapled OCSP response, an OCSP extension **or** a CRL extension must be present.

But I've the following error:

```sh
WARN rustls_platform_verifier::verification::android: certificate was revoked: java.security.cert.CertPathValidatorException: Certificate does not specify OCSP responder    
ERROR rustls_platform_verifier::verification::android: failed to verify TLS certificate: invalid peer certificate: Revoked 
```


I use the latest version of the crate, `0.6.0`.

This MR propose to enable CRL by default on Android