### PR TITLE
feat: Allow to ignore server name checks.

### DIFF
--- a/rustls-platform-verifier/src/verification/mod.rs
+++ b/rustls-platform-verifier/src/verification/mod.rs
@@ -84,3 +84,16 @@ const ALLOWED_EKUS: &[windows_sys::core::PCSTR] =
     &[windows_sys::Win32::Security::Cryptography::szOID_PKIX_KP_SERVER_AUTH];
 #[cfg(target_os = "android")]
 pub const ALLOWED_EKUS: &[&str] = &["1.3.6.1.5.5.7.3.1"];
+
+/// Decide whether to verify the hostname of the certificate.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum HostnameVerification {
+    Verify,
+    Ignore,
+}
+
+impl HostnameVerification {
+    pub fn is_verify(&self) -> bool {
+        self == &HostnameVerification::Verify
+    }
+}


### PR DESCRIPTION
👋 I'm working on [making Rustls the default crypto implementation for Reqwest](https://github.com/seanmonstar/reqwest/pull/2752).

There is a [discussion about adopting this project as the default verifier](https://github.com/seanmonstar/reqwest/issues/2025#issuecomment-2956991896), instead of WebPKI, which is what Reqwest uses by default at the moment. One of the challenges for that adoption is that Reqwest allows to skip server name verifications. [It implements it's own verifier for this feature](https://github.com/seanmonstar/reqwest/blob/master/src/tls.rs#L662-L723).

If we want to adopt this project in Reqwest, I see two options:

1. Use it for the default behavior, and fallback to its own IgnoreHostname verifier when the option is enabled, using WebPKI in that case.
2. Allow this verifier to ignore hostname checks and use it for all cases. What I'm trying to implement in this PR.

I'm not sure if this feature is something you all would even want to have or provide. From my point of view, it'd be cleaner if Reqwest could only use a verifier for all its features.

I'll appreciate your feedback on this change.