### PR TITLE
ci: run iOS tests on ARM

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -125,8 +125,8 @@ jobs:
       - name: Clippy (iOS)
         if: matrix.os == 'macos-latest'
         run: |
-          rustup target add x86_64-apple-ios
-          cargo clippy-msrv-ci --target x86_64-apple-ios
+          rustup target add aarch64-apple-ios
+          cargo clippy-msrv-ci --target aarch64-apple-ios
 
       # TODO: Consider WASM. See note on "clippy" job.
 


### PR DESCRIPTION
```
The following warnings were emitted during compilation:

warning: In file included from /Users/runner/.cargo/registry/src/index.crates.io-6f17d22bba15001f/ring-0.17.14/crypto/curve25519/curve25519.c:22:
warning: In file included from /Users/runner/.cargo/registry/src/index.crates.io-6f17d22bba15001f/ring-0.17.14/include/ring-core/mem.h:18:
warning: In file included from /Users/runner/.cargo/registry/src/index.crates.io-6f17d22bba15001f/ring-0.17.14/include/ring-core/base.h:26:
warning: In file included from /Applications/Xcode_16.4.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/clang/17/include/stdint.h:56:
warning: In file included from /Applications/Xcode_16.4.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS18.5.sdk/usr/include/stdint.h:52:
warning: In file included from /Applications/Xcode_16.4.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS18.5.sdk/usr/include/sys/_types.h:32:
warning: /Applications/Xcode_16.4.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS18.5.sdk/usr/include/sys/cdefs.h:1030:2: error: Unsupported architecture
warning:  1030 | #error Unsupported architecture
warning:       |  ^
warning: In file included from /Users/runner/.cargo/registry/src/index.crates.io-6f17d22bba15001f/ring-0.17.14/crypto/curve25519/curve25519.c:22:
warning: In file included from /Users/runner/.cargo/registry/src/index.crates.io-6f17d22bba15001f/ring-0.17.14/include/ring-core/mem.h:18:
warning: In file included from /Users/runner/.cargo/registry/src/index.crates.io-6f17d22bba15001f/ring-0.17.14/include/ring-core/base.h:26:
warning: In file included from /Applications/Xcode_16.4.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/clang/17/include/stdint.h:56:
warning: In file included from /Applications/Xcode_16.4.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS18.5.sdk/usr/include/stdint.h:52:
warning: In file included from /Applications/Xcode_16.4.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS18.5.sdk/usr/include/sys/_types.h:33:
warning: /Applications/Xcode_16.4.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS18.5.sdk/usr/include/machine/_types.h:34:2: error: architecture not supported
warning:    34 | #error architecture not supported
warning:       |  ^
warning: In file included from /Users/runner/.cargo/registry/src/index.crates.io-6f17d22bba15001f/ring-0.17.14/crypto/curve25519/curve25519.c:22:
warning: In file included from /Users/runner/.cargo/registry/src/index.crates.io-6f17d22bba15001f/ring-0.17.14/include/ring-core/mem.h:18:
warning: In file included from /Users/runner/.cargo/registry/src/index.crates.io-6f17d22bba15001f/ring-0.17.14/include/ring-core/base.h:26:
warning: In file included from /Applications/Xcode_16.4.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/clang/17/include/stdint.h:56:
warning: In file included from /Applications/Xcode_16.4.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS18.5.sdk/usr/include/stdint.h:52:
warning: /Applications/Xcode_16.4.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS18.5.sdk/usr/include/sys/_types.h:67:9: error: unknown type name '__int64_t'
warning:    67 | typedef __int64_t       __darwin_blkcnt_t;      /* total blocks */
warning:       |         ^
warning: /Applications/Xcode_16.4.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS18.5.sdk/usr/include/sys/_types.h:68:9: error: unknown type name '__int32_t'
warning:    68 | typedef __int32_t       __darwin_blksize_t;     /* preferred block size */
warning:       |         ^
warning: /Applications/Xcode_16.4.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS18.5.sdk/usr/include/sys/_types.h:69:9: error: unknown type name '__int32_t'
warning:    69 | typedef __int32_t       __darwin_dev_t;         /* dev_t */
warning:       |         ^
warning: /Applications/Xcode_16.4.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS18.5.sdk/usr/include/sys/_types.h:72:9: error: unknown type name '__uint32_t'
warning:    72 | typedef __uint32_t      __darwin_gid_t;         /* [???] process and group IDs */
warning:       |         ^
warning: /Applications/Xcode_16.4.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS18.5.sdk/usr/include/sys/_types.h:73:9: error: unknown type name '__uint32_t'
warning:    73 | typedef __uint32_t      __darwin_id_t;          /* [XSI] pid_t, uid_t, or gid_t*/
warning:       |         ^
warning: /Applications/Xcode_16.4.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS18.5.sdk/usr/include/sys/_types.h:74:9: error: unknown type name '__uint64_t'; did you mean 'uint64_t'?
warning:    74 | typedef __uint64_t      __darwin_ino64_t;       /* [???] Used for 64 bit inodes */
warning:       |         ^
warning: /Applications/Xcode_16.4.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS18.5.sdk/usr/include/_types/_uint64_t.h:31:28: note: 'uint64_t' declared here
warning:    31 | typedef unsigned long long uint64_t;
warning:       |                            ^
warning: In file included from /Users/runner/.cargo/registry/src/index.crates.io-6f17d22bba15001f/ring-0.17.14/crypto/curve25519/curve25519.c:22:
warning: In file included from /Users/runner/.cargo/registry/src/index.crates.io-6f17d22bba15001f/ring-0.17.14/include/ring-core/mem.h:18:
warning: In file included from /Users/runner/.cargo/registry/src/index.crates.io-6f17d22bba15001f/ring-0.17.14/include/ring-core/base.h:26:
warning: In file included from /Applications/Xcode_16.4.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/clang/17/include/stdint.h:56:
warning: In file included from /Applications/Xcode_16.4.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS18.5.sdk/usr/include/stdint.h:52:
warning: /Applications/Xcode_16.4.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS18.5.sdk/usr/include/sys/_types.h:80:9: error: unknown type name '__darwin_natural_t'
warning:    80 | typedef __darwin_natural_t __darwin_mach_port_name_t; /* Used by mach */
warning:       |         ^
warning: /Applications/Xcode_16.4.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS18.5.sdk/usr/include/sys/_types.h:82:9: error: unknown type name '__uint16_t'
warning:    82 | typedef __uint16_t      __darwin_mode_t;        /* [???] Some file attributes */
warning:       |         ^
warning: /Applications/Xcode_16.4.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS18.5.sdk/usr/include/sys/_types.h:83:9: error: unknown type name '__int64_t'
warning:    83 | typedef __int64_t       __darwin_off_t;         /* [???] Used for file sizes */
warning:       |         ^
warning: /Applications/Xcode_16.4.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS18.5.sdk/usr/include/sys/_types.h:84:9: error: unknown type name '__int32_t'
warning:    84 | typedef __int32_t       __darwin_pid_t;         /* [???] process and group IDs */
warning:       |         ^
warning: /Applications/Xcode_16.4.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS18.5.sdk/usr/include/sys/_types.h:85:9: error: unknown type name '__uint32_t'
warning:    85 | typedef __uint32_t      __darwin_sigset_t;      /* [???] signal set */
warning:       |         ^
warning: /Applications/Xcode_16.4.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS18.5.sdk/usr/include/sys/_types.h:86:9: error: unknown type name '__int32_t'
warning:    86 | typedef __int32_t       __darwin_suseconds_t;   /* [???] microseconds */
warning:       |         ^
warning: /Applications/Xcode_16.4.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS18.5.sdk/usr/include/sys/_types.h:87:9: error: unknown type name '__uint32_t'
warning:    87 | typedef __uint32_t      __darwin_uid_t;         /* [???] user IDs */
warning:       |         ^
warning: /Applications/Xcode_16.4.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS18.5.sdk/usr/include/sys/_types.h:88:9: error: unknown type name '__uint32_t'
warning:    88 | typedef __uint32_t      __darwin_useconds_t;    /* [???] microseconds */
warning:       |         ^
warning: In file included from /Users/runner/.cargo/registry/src/index.crates.io-6f17d22bba15001f/ring-0.17.14/crypto/curve25519/curve25519.c:22:
warning: In file included from /Users/runner/.cargo/registry/src/index.crates.io-6f17d22bba15001f/ring-0.17.14/include/ring-core/mem.h:18:
warning: In file included from /Users/runner/.cargo/registry/src/index.crates.io-6f17d22bba15001f/ring-0.17.14/include/ring-core/base.h:26:
warning: In file included from /Applications/Xcode_16.4.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/clang/17/include/stdint.h:56:
warning: In file included from /Applications/Xcode_16.4.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS18.5.sdk/usr/include/stdint.h:53:
warning: /Applications/Xcode_16.4.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS18.5.sdk/usr/include/sys/_types/_intptr_t.h:32:9: error: unknown type name '__darwin_intptr_t'
warning:    32 | typedef __darwin_intptr_t       intptr_t;
warning:       |         ^
warning: In file included from /Users/runner/.cargo/registry/src/index.crates.io-6f17d22bba15001f/ring-0.17.14/crypto/curve25519/curve25519.c:24:
warning: In file included from /Users/runner/.cargo/registry/src/index.crates.io-6f17d22bba15001f/ring-0.17.14/crypto/curve25519/internal.h:20:
warning: In file included from /Users/runner/.cargo/registry/src/index.crates.io-6f17d22bba15001f/ring-0.17.14/crypto/curve25519/../internal.h:361:
warning: In file included from /Applications/Xcode_16.4.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS18.5.sdk/usr/include/string.h:58:
warning: In file included from /Applications/Xcode_16.4.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS18.5.sdk/usr/include/_string.h:62:
warning: /Applications/Xcode_16.4.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS18.5.sdk/usr/include/_types.h:46:9: error: unknown type name '__uint32_t'
warning:    46 | typedef __uint32_t      __darwin_wctype_t;
warning:       |         ^
warning: In file included from /Users/runner/.cargo/registry/src/index.crates.io-6f17d22bba15001f/ring-0.17.14/crypto/curve25519/curve25519.c:24:
warning: In file included from /Users/runner/.cargo/registry/src/index.crates.io-6f17d22bba15001f/ring-0.17.14/crypto/curve25519/internal.h:20:
warning: In file included from /Users/runner/.cargo/registry/src/index.crates.io-6f17d22bba15001f/ring-0.17.14/crypto/curve25519/../internal.h:361:
warning: In file included from /Applications/Xcode_16.4.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS18.5.sdk/usr/include/string.h:58:
warning: In file included from /Applications/Xcode_16.4.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS18.5.sdk/usr/include/_string.h:183:
warning: In file included from /Applications/Xcode_16.4.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS18.5.sdk/usr/include/sys/_types/_ssize_t.h:30:
warning: /Applications/Xcode_16.4.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS18.5.sdk/usr/include/machine/types.h:37:2: error: architecture not supported
warning:    37 | #error architecture not supported
warning:       |  ^
warning: fatal error: too many errors emitted, stopping now [-ferror-limit=]
warning: 20 errors generated.

error: failed to run custom build command for `ring v0.17.14`
```