### PR TITLE
Allow macOS 10.12 and 10.13 to work

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -315,9 +315,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework"
-version = "3.2.0"
+version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "271720403f46ca04f7ba6f55d438f8bd878d6b8ca0a1046e8228c4145bcbb316"
+checksum = "cc198e42d9b7510827939c9a15f5062a0c913f3371d765977e586d2fe6c16f4a"
 dependencies = [
  "bitflags",
  "core-foundation",
@@ -328,9 +328,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework-sys"
-version = "2.14.0"
+version = "2.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49db231d56a190491cb4aeda9527f1ad45345af50b0851622a7adb8c03b01c32"
+checksum = "cc1f0cbffaac4852523ce30d8bd3c5cdc873501d96ff467ca09b6767bb8cd5c0"
 dependencies = [
  "core-foundation-sys",
  "libc",

--- a/rustls-platform-verifier/Cargo.toml
+++ b/rustls-platform-verifier/Cargo.toml
@@ -53,8 +53,8 @@ webpki-root-certs = "1"
 [target.'cfg(any(target_vendor = "apple"))'.dependencies]
 core-foundation = "0.10"
 core-foundation-sys = "0.8"
-security-framework = { version = "3", features = ["OSX_10_14"] }
-security-framework-sys = { version = "2.10", features = ["OSX_10_14"] }
+security-framework = "3.5.0"
+security-framework-sys = "2.15"
 
 [target.'cfg(windows)'.dependencies]
 windows-sys = { version = ">=0.52.0, <0.60.0", default-features = false, features = ["Win32_Foundation", "Win32_Security_Cryptography"] }


### PR DESCRIPTION
Since https://github.com/kornelski/rust-security-framework/pull/243, `security-framework` now dynamically looks up the newer symbol `SecTrustEvaluateWithError`, and only if it's not available does it fall back to `SecTrustEvaluate`. This allows `rustls-platform-verifier` to support macOS 10.12 while still having good error messages on newer versions.

Fixes https://github.com/rustls/rustls-platform-verifier/issues/188.