### PR TITLE
Make cdylib crate type optional

### DIFF
--- a/android/rustls-platform-verifier/build.gradle
+++ b/android/rustls-platform-verifier/build.gradle
@@ -50,7 +50,7 @@ android {
 
     task buildTestLib(type: Exec) {
         workingDir "../../"
-        commandLine "cargo", "ndk", "-t", getOsArch(), "-o", "android/rustls-platform-verifier/src/androidTest/jniLibs", "build", "-p", "rustls-platform-verifier", "--features", "ffi-testing"
+        commandLine "cargo", "ndk", "-t", getOsArch(), "-o", "android/rustls-platform-verifier/src/androidTest/jniLibs", "rustc", "-p", "rustls-platform-verifier", "--features", "ffi-testing", "--crate-type", "cdylib"
     }
 
     // Only compile the test library if this package is being built for testing by itself.

--- a/rustls-platform-verifier/Cargo.toml
+++ b/rustls-platform-verifier/Cargo.toml
@@ -11,9 +11,6 @@ rust-version = "1.71.0"
 
 [lib]
 name = "rustls_platform_verifier"
-# Note: The `cdylib` specification is for testing only. The shared library
-# is not expected to have a stable API.
-crate-type = ["cdylib", "rlib"]
 
 [features]
 # Enables a C interface to use for testing where `cargo` can't be used.


### PR DESCRIPTION
Related to https://github.com/rusterlium/rustler/issues/707.

The cdylib is built unconditionally, which leads to it always being included in deployment processes that parse cargo's messages. This change should make the cdylib optional.
