### PR TITLE
Release 0.6.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -271,7 +271,7 @@ dependencies = [
 
 [[package]]
 name = "rustls-platform-verifier"
-version = "0.6.1"
+version = "0.6.2"
 dependencies = [
  "android_logger",
  "base64",

--- a/rustls-platform-verifier/Cargo.toml
+++ b/rustls-platform-verifier/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rustls-platform-verifier"
-version = "0.6.1"
+version = "0.6.2"
 description = "rustls-platform-verifier supports verifying TLS certificates in rustls with the operating system verifier"
 keywords = ["tls", "certificate", "verification", "os", "native"]
 repository = "https://github.com/rustls/rustls-platform-verifier"


### PR DESCRIPTION
We've had a number of improvements and bugfixes made since the last release, so I think its a good time to publish again.

AFAICT there have been no breaking changes since `0.6.1`, so a new patch version should be OK.