### PR TITLE
windows: add Verifier::offline() constructor

### DIFF
--- a/rustls-platform-verifier/src/verification/windows.rs
+++ b/rustls-platform-verifier/src/verification/windows.rs
@@ -88,7 +88,7 @@ impl Verifier {
 
     /// Creates a new instance of a TLS certificate verifier that utilizes the
     /// Windows certificate facilities and augmented by the provided extra root certificates.
-    #[cfg_attr(docsrs, doc(cfg(not(target_os = "android"))))]
+    #[cfg_attr(docsrs, doc(cfg(all())))]
     pub fn new_with_extra_roots(
         roots: impl IntoIterator<Item = pki_types::CertificateDer<'static>>,
         crypto_provider: Arc<CryptoProvider>,

--- a/rustls-platform-verifier/src/verification/windows.rs
+++ b/rustls-platform-verifier/src/verification/windows.rs
@@ -129,7 +129,7 @@ impl Verifier {
         #[cfg(any(test, feature = "ffi-testing", feature = "dbg"))]
         let mut store = match self.test_only_root_ca_override.as_ref() {
             Some(test_only_root_ca_override) => {
-                CertificateStore::new_with_fake_root(test_only_root_ca_override.clone())?
+                CertificateStore::for_testing(test_only_root_ca_override.clone())?
             }
             None => CertificateStore::new()?,
         };
@@ -304,7 +304,7 @@ impl CertEngine {
     }
 
     #[cfg(any(test, feature = "ffi-testing", feature = "dbg"))]
-    fn new_with_fake_root(root: pki_types::CertificateDer<'static>) -> Result<Self, TlsError> {
+    fn for_testing(root: pki_types::CertificateDer<'static>) -> Result<Self, TlsError> {
         // We use these flags for the following reasons:
         //
         // - CERT_CHAIN_CACHE_ONLY_URL_RETRIEVAL is used in an attempt to stop Windows from using the internet to
@@ -383,11 +383,11 @@ struct CertificateStore {
 
 impl CertificateStore {
     #[cfg(any(test, feature = "ffi-testing", feature = "dbg"))]
-    fn new_with_fake_root(root: pki_types::CertificateDer<'static>) -> Result<Self, TlsError> {
+    fn for_testing(root: pki_types::CertificateDer<'static>) -> Result<Self, TlsError> {
         let mut inner = Self::new()?;
         inner.add_cert(&root)?;
 
-        let engine = CertEngine::new_with_fake_root(root)?;
+        let engine = CertEngine::for_testing(root)?;
         inner.engine = Some(engine);
 
         Ok(inner)

--- a/rustls-platform-verifier/src/verification/windows.rs
+++ b/rustls-platform-verifier/src/verification/windows.rs
@@ -300,37 +300,11 @@ impl CertEngine {
     fn new_with_extra_roots(
         roots: impl IntoIterator<Item = pki_types::CertificateDer<'static>>,
     ) -> Result<Self, TlsError> {
-        let mut exclusive_store = CertificateStore::new()?;
-        for root in roots {
-            exclusive_store.add_cert(&root)?;
-        }
-
-        let mut config = CERT_CHAIN_ENGINE_CONFIG::zeroed_with_size();
-        config.hExclusiveRoot = exclusive_store.inner.as_ptr();
-
-        let mut engine = EnginePtr::NULL;
-
-        // XXX: Due to the redefinition of `CERT_CHAIN_ENGINE_CONFIG`, we need to do pointer casts
-        // in order to pass our expanded structure into `CertCreateCertificateChainEngine`.
-        // See also `CERT_CHAIN_PARA` casting below.
-        let config = NonNull::from(&config).cast().as_ptr();
-        // SAFETY: `engine` is valid to be written to and the config is valid to be read.
-        let res = unsafe { CertCreateCertificateChainEngine(config, &mut engine) };
-
-        #[allow(clippy::as_conversions)]
-        let engine = call_with_last_error(|| match NonNull::new(engine as *mut c_void) {
-            Some(c) if res == TRUE => Some(c),
-            _ => None,
-        })?;
-        Ok(Self { inner: engine })
+        Self::new(roots, 0)
     }
 
     #[cfg(any(test, feature = "ffi-testing", feature = "dbg"))]
     fn new_with_fake_root(root: pki_types::CertificateDer<'static>) -> Result<Self, TlsError> {
-        let mut root_store = CertificateStore::new()?;
-        root_store.add_cert(&root)?;
-
-        let mut config = CERT_CHAIN_ENGINE_CONFIG::zeroed_with_size();
         // We use these flags for the following reasons:
         //
         // - CERT_CHAIN_CACHE_ONLY_URL_RETRIEVAL is used in an attempt to stop Windows from using the internet to
@@ -340,11 +314,29 @@ impl CertEngine {
         // data inside of a test and avoid any extra parsing, etc, it might need to do pulling directly from the store each time.
         //
         // Ref: https://docs.microsoft.com/en-us/windows/win32/api/wincrypt/ns-wincrypt-cert_chain_engine_config
-        config.dwFlags = CERT_CHAIN_CACHE_ONLY_URL_RETRIEVAL | CERT_CHAIN_ENABLE_CACHE_AUTO_UPDATE;
-        config.hExclusiveRoot = root_store.inner.as_ptr();
+        Self::new(
+            [root],
+            CERT_CHAIN_CACHE_ONLY_URL_RETRIEVAL | CERT_CHAIN_ENABLE_CACHE_AUTO_UPDATE,
+        )
+    }
 
+    fn new(
+        roots: impl IntoIterator<Item = pki_types::CertificateDer<'static>>,
+        flags: u32,
+    ) -> Result<Self, TlsError> {
+        let mut store = CertificateStore::new()?;
+        for root in roots {
+            store.add_cert(&root)?;
+        }
+
+        let mut config = CERT_CHAIN_ENGINE_CONFIG::zeroed_with_size();
+        config.hExclusiveRoot = store.inner.as_ptr();
+        config.dwFlags = flags;
         let mut engine = EnginePtr::NULL;
-        // Same workaround with as above when creating the engine.
+
+        // XXX: Due to the redefinition of `CERT_CHAIN_ENGINE_CONFIG`, we need to do pointer casts
+        // in order to pass our expanded structure into `CertCreateCertificateChainEngine`.
+        // See also `CERT_CHAIN_PARA` casting below.
         let config = NonNull::from(&config).cast().as_ptr();
         // SAFETY: `engine` is valid to be written to and the config is valid to be read.
         let res = unsafe { CertCreateCertificateChainEngine(config, &mut engine) };

--- a/rustls-platform-verifier/src/verification/windows.rs
+++ b/rustls-platform-verifier/src/verification/windows.rs
@@ -59,484 +59,7 @@ use windows_sys::Win32::{
     },
 };
 
-use super::{log_server_cert, ALLOWED_EKUS};
-
-// The `windows-sys` definition for `CERT_CHAIN_PARA` does not take old OS versions
-// into account so we define it ourselves for better OS backwards compat.
-// In the future a compile-time size assertion can be added against the upstream type to help stay in sync.
-#[allow(non_camel_case_types, non_snake_case)]
-#[repr(C)]
-struct CERT_CHAIN_PARA {
-    pub cbSize: u32,
-    pub RequestedUsage: CERT_USAGE_MATCH,
-    pub RequestedIssuancePolicy: CERT_USAGE_MATCH,
-    pub dwUrlRetrievalTimeout: u32,
-    pub fCheckRevocationFreshnessTime: i32, // BOOL
-    pub dwRevocationFreshnessTime: u32,
-    pub pftCacheResync: *mut FILETIME,
-    // XXX: `pStrongSignPara` and `dwStrongSignFlags` might or might not be defined on the current system. It started
-    // being available in Windows 8. See https://docs.microsoft.com/en-us/windows/win32/api/wincrypt/ns-wincrypt-cert_chain_para
-    #[cfg(not(target_vendor = "win7"))]
-    pub pStrongSignPara: *const CERT_STRONG_SIGN_PARA,
-    #[cfg(not(target_vendor = "win7"))]
-    pub dwStrongSignFlags: u32,
-}
-
-// Same workaround with CERT_CHAIN_PARA
-#[allow(non_camel_case_types, non_snake_case)]
-#[repr(C)]
-#[derive(Clone, Copy)]
-pub struct CERT_CHAIN_ENGINE_CONFIG {
-    pub cbSize: u32,
-    pub hRestrictedRoot: HCERTSTORE,
-    pub hRestrictedTrust: HCERTSTORE,
-    pub hRestrictedOther: HCERTSTORE,
-    pub cAdditionalStore: u32,
-    pub rghAdditionalStore: *mut HCERTSTORE,
-    pub dwFlags: u32,
-    pub dwUrlRetrievalTimeout: u32,
-    pub MaximumCachedCertificates: u32,
-    pub CycleDetectionModulus: u32,
-    pub hExclusiveRoot: HCERTSTORE,
-    pub hExclusiveTrustedPeople: HCERTSTORE,
-    // XXX: `dwExclusiveFlags` started being available in Windows 8 and Windows Server 2012
-    // See https://learn.microsoft.com/en-us/windows/win32/api/wincrypt/ns-wincrypt-cert_chain_engine_config
-    #[cfg(not(target_vendor = "win7"))]
-    pub dwExclusiveFlags: u32,
-}
-
-use crate::verification::invalid_certificate;
-
-// SAFETY: see method implementation
-unsafe impl ZeroedWithSize for CERT_CHAIN_PARA {
-    fn zeroed_with_size() -> Self {
-        // SAFETY: `CERT_CHAIN_PARA` only contains pointers and integers, which are safe to zero.
-        // Additionally, MSDN states you *MUST* zero all unused fields.
-        let mut new: Self = unsafe { mem::zeroed() };
-        new.cbSize = Self::SIZE;
-        new
-    }
-}
-
-// SAFETY: see method implementation
-unsafe impl ZeroedWithSize for HTTPSPolicyCallbackData {
-    fn zeroed_with_size() -> Self {
-        // SAFETY: zeroed is needed here since it contains a union.
-        let mut new: Self = unsafe { mem::zeroed() };
-        new.Anonymous.cbSize = Self::SIZE;
-        new
-    }
-}
-
-// SAFETY: see method implementation
-unsafe impl ZeroedWithSize for CERT_CHAIN_POLICY_PARA {
-    fn zeroed_with_size() -> Self {
-        // SAFETY: This structure only contains integers and pointers.
-        let mut new: Self = unsafe { mem::zeroed() };
-        new.cbSize = Self::SIZE;
-        new
-    }
-}
-
-// SAFETY: see method implementation
-unsafe impl ZeroedWithSize for CERT_CHAIN_ENGINE_CONFIG {
-    fn zeroed_with_size() -> Self {
-        // SAFETY: This structure only contains integers and pointers.
-        let mut new: Self = unsafe { mem::zeroed() };
-        new.cbSize = Self::SIZE;
-        new
-    }
-}
-
-struct CertChain {
-    inner: NonNull<CERT_CHAIN_CONTEXT>,
-}
-
-impl CertChain {
-    fn verify_chain_policy(
-        &self,
-        mut server_null_terminated: Vec<u16>,
-    ) -> Result<CERT_CHAIN_POLICY_STATUS, TlsError> {
-        let mut extra_params = HTTPSPolicyCallbackData::zeroed_with_size();
-        extra_params.dwAuthType = AUTHTYPE_SERVER;
-        // `server_null_terminated` outlives `extra_params`.
-        extra_params.pwszServerName = server_null_terminated.as_mut_ptr();
-
-        let mut params = CERT_CHAIN_POLICY_PARA::zeroed_with_size();
-        // Ignore any errors when trying to obtain OCSP revocation information.
-        // This is also done in OpenSSL, Secure Transport from Apple, etc.
-        params.dwFlags = CERT_CHAIN_POLICY_IGNORE_ALL_REV_UNKNOWN_FLAGS;
-        // `extra_params` outlives `params`.
-        params.pvExtraPolicyPara = NonNull::from(&mut extra_params).cast::<c_void>().as_ptr();
-
-        let mut status: MaybeUninit<CERT_CHAIN_POLICY_STATUS> = MaybeUninit::uninit();
-
-        // SAFETY: The certificate chain is non-null, `params` is valid for reads, and its valid to write to `status`.
-        let res = unsafe {
-            CertVerifyCertificateChainPolicy(
-                CERT_CHAIN_POLICY_SSL,
-                self.inner.as_ptr(),
-                &params,
-                status.as_mut_ptr(),
-            )
-        };
-
-        // This should rarely, if ever, be false since it would imply no TLS verification
-        // is currently possible on the system: https://docs.microsoft.com/en-us/windows/win32/api/wincrypt/nf-wincrypt-certverifycertificatechainpolicy#return-value
-        if res != TRUE {
-            return Err(TlsError::General(String::from(
-                "TLS certificate verification was unavailable on the system!",
-            )));
-        }
-
-        // SAFETY: The verification call was checked to have succeeded, so the status
-        // is written correctly and initialized.
-        let status = unsafe { status.assume_init() };
-        Ok(status)
-    }
-}
-
-impl Drop for CertChain {
-    fn drop(&mut self) {
-        // SAFETY: The pointer is guaranteed to be non-null.
-        unsafe { CertFreeCertificateChain(self.inner.as_ptr()) }
-    }
-}
-
-/// A representation of a certificate.
-///
-/// The `CertificateStore` must be opened with the correct flags to ensure the
-/// certificate may outlive it; see the `CertificateStore` documentation.
-struct Certificate {
-    inner: NonNull<CERT_CONTEXT>,
-}
-
-impl Certificate {
-    /// Sets the specified property of this certificate context.
-    ///
-    /// ### Safety
-    /// `prop_data` must be a valid pointer for the property type.
-    unsafe fn set_property(
-        &mut self,
-        prop_id: u32,
-        prop_data: *const c_void,
-    ) -> Result<(), TlsError> {
-        // SAFETY: `cert` points to a valid certificate context and the OCSP data is valid to read.
-        call_with_last_error(|| {
-            (CertSetCertificateContextProperty(
-                self.inner.as_ptr(),
-                prop_id,
-                CERT_SET_PROPERTY_IGNORE_PERSIST_ERROR_FLAG,
-                prop_data,
-            ) == TRUE)
-                .then_some(())
-        })
-    }
-}
-
-impl Drop for Certificate {
-    fn drop(&mut self) {
-        // SAFETY: The certificate context is non-null and points to a valid location.
-        unsafe { CertFreeCertificateContext(self.inner.as_ptr()) };
-    }
-}
-
-#[derive(Debug)]
-struct CertEngine {
-    inner: NonNull<c_void>, // HCERTENGINECONTEXT
-}
-
-impl CertEngine {
-    fn new_with_extra_roots(
-        roots: impl IntoIterator<Item = pki_types::CertificateDer<'static>>,
-    ) -> Result<Self, TlsError> {
-        let mut exclusive_store = CertificateStore::new()?;
-        for root in roots {
-            exclusive_store.add_cert(&root)?;
-        }
-
-        let mut config = CERT_CHAIN_ENGINE_CONFIG::zeroed_with_size();
-        config.hExclusiveRoot = exclusive_store.inner.as_ptr();
-
-        let mut engine = EnginePtr::NULL;
-
-        // XXX: Due to the redefinition of `CERT_CHAIN_ENGINE_CONFIG`, we need to do pointer casts
-        // in order to pass our expanded structure into `CertCreateCertificateChainEngine`.
-        // See also `CERT_CHAIN_PARA` casting below.
-        let config = NonNull::from(&config).cast().as_ptr();
-        // SAFETY: `engine` is valid to be written to and the config is valid to be read.
-        let res = unsafe { CertCreateCertificateChainEngine(config, &mut engine) };
-
-        #[allow(clippy::as_conversions)]
-        let engine = call_with_last_error(|| match NonNull::new(engine as *mut c_void) {
-            Some(c) if res == TRUE => Some(c),
-            _ => None,
-        })?;
-        Ok(Self { inner: engine })
-    }
-
-    #[cfg(any(test, feature = "ffi-testing", feature = "dbg"))]
-    fn new_with_fake_root(root: &[u8]) -> Result<Self, TlsError> {
-        let mut root_store = CertificateStore::new()?;
-        root_store.add_cert(root)?;
-
-        let mut config = CERT_CHAIN_ENGINE_CONFIG::zeroed_with_size();
-        // We use these flags for the following reasons:
-        //
-        // - CERT_CHAIN_CACHE_ONLY_URL_RETRIEVAL is used in an attempt to stop Windows from using the internet to
-        // fetch anything during the tests, regardless of what test data is used.
-        //
-        // - CERT_CHAIN_ENABLE_CACHE_AUTO_UPDATE is used as a minor performance optimization to allow Windows to reuse
-        // data inside of a test and avoid any extra parsing, etc, it might need to do pulling directly from the store each time.
-        //
-        // Ref: https://docs.microsoft.com/en-us/windows/win32/api/wincrypt/ns-wincrypt-cert_chain_engine_config
-        config.dwFlags = CERT_CHAIN_CACHE_ONLY_URL_RETRIEVAL | CERT_CHAIN_ENABLE_CACHE_AUTO_UPDATE;
-        config.hExclusiveRoot = root_store.inner.as_ptr();
-
-        let mut engine = EnginePtr::NULL;
-        // Same workaround with as above when creating the engine.
-        let config = NonNull::from(&config).cast().as_ptr();
-        // SAFETY: `engine` is valid to be written to and the config is valid to be read.
-        let res = unsafe { CertCreateCertificateChainEngine(config, &mut engine) };
-
-        #[allow(clippy::as_conversions)]
-        let engine = call_with_last_error(|| match NonNull::new(engine as *mut c_void) {
-            Some(c) if res == TRUE => Some(c),
-            _ => None,
-        })?;
-
-        Ok(Self { inner: engine })
-    }
-}
-
-impl Drop for CertEngine {
-    fn drop(&mut self) {
-        // SAFETY: The engine pointer is guaranteed to be non-null.
-        unsafe { CertFreeCertificateChainEngine(EnginePtr::from_raw(self.inner)) };
-    }
-}
-
-// SAFETY: We know no other threads is mutating the `CertEngine`, because it would require `unsafe`.
-// Across the FFI, `CertGetCertificateChain` don't mutate it either.
-unsafe impl Sync for CertEngine {}
-// SAFETY: All methods of `CertEngine`, including `Drop`, are safe to be called from other
-// threads, because all contained resources are owned by Windows and we only maintain reference counted handles to them.
-unsafe impl Send for CertEngine {}
-
-/// An in-memory Windows certificate store.
-///
-/// # Safety
-///
-/// `CertificateStore` creates `Certificate` objects that may outlive the
-/// `CertificateStore`. This is only safe to do if the certificate store is
-/// constructed with `CERT_STORE_DEFER_CLOSE_UNTIL_LAST_FREE_FLAG`.
-struct CertificateStore {
-    inner: NonNull<c_void>, // HCERTSTORE
-    // In production code, this is always `None`.
-    //
-    // During tests, we set this to `Some` as the tests use a
-    // custom verification engine that only uses specific roots.
-    engine: Option<CertEngine>, // HCERTENGINECONTEXT
-}
-
-impl Drop for CertificateStore {
-    fn drop(&mut self) {
-        // SAFETY: See the `CertificateStore` documentation.
-        unsafe { CertCloseStore(self.inner.as_ptr(), 0) };
-    }
-}
-
-impl CertificateStore {
-    /// Creates a new, in-memory certificate store.
-    fn new() -> Result<Self, TlsError> {
-        let store = call_with_last_error(|| {
-            // SAFETY: Called with valid constants and result is checked to be non-null.
-            // The `CERT_STORE_DEFER_CLOSE_UNTIL_LAST_FREE_FLAG` flag is critical;
-            // see the `CertificateStore` documentation for more info.
-            NonNull::new(unsafe {
-                CertOpenStore(
-                    CERT_STORE_PROV_MEMORY,
-                    0, // Set to zero since this uses `PROV_MEMORY`.
-                    0, // This field shouldn't be used.
-                    CERT_STORE_DEFER_CLOSE_UNTIL_LAST_FREE_FLAG,
-                    ptr::null(),
-                )
-            })
-        })?;
-
-        // Use the system's default root store and rules.
-        Ok(Self {
-            inner: store,
-            engine: None,
-        })
-    }
-
-    #[cfg(any(test, feature = "ffi-testing", feature = "dbg"))]
-    fn new_with_fake_root(root: &[u8]) -> Result<Self, TlsError> {
-        let mut inner = Self::new()?;
-
-        let mut root_store = CertificateStore::new()?;
-        root_store.add_cert(root)?;
-
-        let engine = CertEngine::new_with_fake_root(root)?;
-        inner.engine = Some(engine);
-
-        Ok(inner)
-    }
-
-    /// Adds the provided certificate to the store.
-    ///
-    /// The certificate must be encoded as ASN.1 DER.
-    ///
-    /// Errors if the certificate was malformed and couldn't be added.
-    fn add_cert(&mut self, cert: &[u8]) -> Result<Certificate, TlsError> {
-        let mut cert_context: *mut CERT_CONTEXT = ptr::null_mut();
-
-        // SAFETY: `inner` is a valid certificate store, and `cert` is a valid a byte array valid
-        // for reads, the correct length is being provided, and `cert_context` is valid to write to.
-        let res = unsafe {
-            CertAddEncodedCertificateToStore(
-                self.inner.as_ptr(),
-                X509_ASN_ENCODING,
-                cert.as_ptr(),
-                cert.len()
-                    .try_into()
-                    .map_err(|_| InvalidCertificate(CertificateError::BadEncoding))?,
-                CERT_STORE_ADD_ALWAYS,
-                &mut cert_context,
-            )
-        };
-
-        // SAFETY: Constructing a `Certificate` is only safe if the store was
-        // created with the right flags; see the `CertificateStore` docs.
-        match (res, NonNull::new(cert_context)) {
-            (TRUE, Some(cert)) => Ok(Certificate { inner: cert }),
-            _ => Err(InvalidCertificate(CertificateError::BadEncoding)),
-        }
-    }
-
-    fn new_chain_in(
-        &self,
-        certificate: &Certificate,
-        now: pki_types::UnixTime,
-        engine: Option<&CertEngine>,
-    ) -> Result<CertChain, TlsError> {
-        let mut cert_chain = ptr::null_mut();
-
-        let mut parameters = CERT_CHAIN_PARA::zeroed_with_size();
-
-        #[allow(clippy::as_conversions)]
-        // https://docs.microsoft.com/en-us/windows/win32/api/wincrypt/ns-wincrypt-cert_usage_match
-        let usage = CERT_USAGE_MATCH {
-            dwType: USAGE_MATCH_TYPE_AND,
-            Usage: CTL_USAGE {
-                cUsageIdentifier: ALLOWED_EKUS.len() as u32,
-                rgpszUsageIdentifier: ALLOWED_EKUS.as_ptr() as *mut windows_sys::core::PSTR,
-            },
-        };
-        parameters.RequestedUsage = usage;
-
-        #[allow(clippy::as_conversions)]
-        let time = {
-            /// Seconds between Jan 1st, 1601 and Jan 1, 1970.
-            const UNIX_ADJUSTMENT: std::time::Duration =
-                std::time::Duration::from_secs(11_644_473_600);
-
-            let since_unix_epoch = now.as_secs();
-
-            // Convert the duration from the UNIX epoch to the Window one, and then convert
-            // the result into a `FILETIME` structure.
-
-            let since_windows_epoch = since_unix_epoch + UNIX_ADJUSTMENT.as_secs();
-            let intervals = (since_windows_epoch * 1_000_000_000) / 100;
-
-            FILETIME {
-                dwLowDateTime: (intervals & u32::MAX as u64) as u32,
-                dwHighDateTime: (intervals >> 32) as u32,
-            }
-        };
-
-        // `CERT_CHAIN_REVOCATION_CHECK_END_CERT` only checks revocation for end cert. See the crate's revocation documentation
-        // for more details.
-        // `CERT_CHAIN_REVOCATION_ACCUMULATIVE_TIMEOUT` accumulates network retrievals timeouts
-        // to limit network time and improve performance.
-        // `CERT_CHAIN_CACHE_END_CERT` speeds up the common case of multiple connections to same server.
-        const FLAGS: u32 = CERT_CHAIN_REVOCATION_CHECK_END_CERT
-            | CERT_CHAIN_REVOCATION_ACCUMULATIVE_TIMEOUT
-            | CERT_CHAIN_CACHE_END_CERT;
-
-        // Lowering URL retrieval timeout from default 15s to 10s to account for higher internet speeds
-        parameters.dwUrlRetrievalTimeout = 3 * 1000; // milliseconds
-
-        // SAFETY: `cert` points to a valid certificate context, parameters is valid for reads, `cert_chain` is valid
-        // for writes, and the certificate store is valid and initialized.
-        let res = unsafe {
-            // XXX: Due to the redefinition of `CERT_CHAIN_PARA`, we need to do pointer casts
-            // in order to pass our expanded structure into `CertGetCertificateChain`.
-            // This is safe because the OS uses `cbSize` to know if the extra parameters
-            // are present or not. As we set `cbSize` correctly, the fields can be read from correctly.
-            let parameters = NonNull::from(&parameters).cast().as_ptr();
-
-            CertGetCertificateChain(
-                match engine {
-                    Some(eng) => EnginePtr::from_raw(eng.inner),
-                    None => EnginePtr::NULL,
-                },
-                certificate.inner.as_ptr(),
-                &time,
-                self.inner.as_ptr(),
-                parameters,
-                FLAGS,
-                ptr::null_mut(),
-                &mut cert_chain,
-            )
-        };
-
-        // XXX: Windows will internally map the chain's `TrustStatus.dwErrorStatus` to a `dwError` when
-        // a chain policy is verified, so we only check for errors there.
-        call_with_last_error(|| match NonNull::new(cert_chain) {
-            Some(c) if res == TRUE => Some(CertChain { inner: c }),
-            _ => None,
-        })
-    }
-}
-
-// `windows-sys` >= 0.60
-impl EnginePtr for *mut c_void {
-    fn from_raw(val: NonNull<c_void>) -> Self {
-        val.as_ptr()
-    }
-
-    const NULL: Self = ptr::null_mut();
-}
-
-// `windows-sys` 0.52-0.59
-impl EnginePtr for isize {
-    #[allow(clippy::as_conversions)]
-    fn from_raw(val: NonNull<c_void>) -> Self {
-        val.as_ptr() as isize
-    }
-
-    const NULL: Self = 0;
-}
-
-/// An abstraction trait over the different ways various `windows-sys` versions represent
-/// the type of `HCERTCHAINENGINE`.
-trait EnginePtr: Sized {
-    fn from_raw(val: NonNull<c_void>) -> Self;
-
-    const NULL: Self;
-}
-
-fn call_with_last_error<T, F: FnMut() -> Option<T>>(mut call: F) -> Result<T, TlsError> {
-    if let Some(res) = call() {
-        Ok(res)
-    } else {
-        Err(TlsError::General(
-            std::io::Error::last_os_error().to_string(),
-        ))
-    }
-}
+use super::{invalid_certificate, log_server_cert, ALLOWED_EKUS};
 
 /// A TLS certificate verifier that utilizes the Windows certificate facilities.
 #[derive(Debug)]
@@ -768,6 +291,471 @@ impl ServerCertVerifier for Verifier {
     }
 }
 
+#[derive(Debug)]
+struct CertEngine {
+    inner: NonNull<c_void>, // HCERTENGINECONTEXT
+}
+
+impl CertEngine {
+    fn new_with_extra_roots(
+        roots: impl IntoIterator<Item = pki_types::CertificateDer<'static>>,
+    ) -> Result<Self, TlsError> {
+        let mut exclusive_store = CertificateStore::new()?;
+        for root in roots {
+            exclusive_store.add_cert(&root)?;
+        }
+
+        let mut config = CERT_CHAIN_ENGINE_CONFIG::zeroed_with_size();
+        config.hExclusiveRoot = exclusive_store.inner.as_ptr();
+
+        let mut engine = EnginePtr::NULL;
+
+        // XXX: Due to the redefinition of `CERT_CHAIN_ENGINE_CONFIG`, we need to do pointer casts
+        // in order to pass our expanded structure into `CertCreateCertificateChainEngine`.
+        // See also `CERT_CHAIN_PARA` casting below.
+        let config = NonNull::from(&config).cast().as_ptr();
+        // SAFETY: `engine` is valid to be written to and the config is valid to be read.
+        let res = unsafe { CertCreateCertificateChainEngine(config, &mut engine) };
+
+        #[allow(clippy::as_conversions)]
+        let engine = call_with_last_error(|| match NonNull::new(engine as *mut c_void) {
+            Some(c) if res == TRUE => Some(c),
+            _ => None,
+        })?;
+        Ok(Self { inner: engine })
+    }
+
+    #[cfg(any(test, feature = "ffi-testing", feature = "dbg"))]
+    fn new_with_fake_root(root: &[u8]) -> Result<Self, TlsError> {
+        let mut root_store = CertificateStore::new()?;
+        root_store.add_cert(root)?;
+
+        let mut config = CERT_CHAIN_ENGINE_CONFIG::zeroed_with_size();
+        // We use these flags for the following reasons:
+        //
+        // - CERT_CHAIN_CACHE_ONLY_URL_RETRIEVAL is used in an attempt to stop Windows from using the internet to
+        // fetch anything during the tests, regardless of what test data is used.
+        //
+        // - CERT_CHAIN_ENABLE_CACHE_AUTO_UPDATE is used as a minor performance optimization to allow Windows to reuse
+        // data inside of a test and avoid any extra parsing, etc, it might need to do pulling directly from the store each time.
+        //
+        // Ref: https://docs.microsoft.com/en-us/windows/win32/api/wincrypt/ns-wincrypt-cert_chain_engine_config
+        config.dwFlags = CERT_CHAIN_CACHE_ONLY_URL_RETRIEVAL | CERT_CHAIN_ENABLE_CACHE_AUTO_UPDATE;
+        config.hExclusiveRoot = root_store.inner.as_ptr();
+
+        let mut engine = EnginePtr::NULL;
+        // Same workaround with as above when creating the engine.
+        let config = NonNull::from(&config).cast().as_ptr();
+        // SAFETY: `engine` is valid to be written to and the config is valid to be read.
+        let res = unsafe { CertCreateCertificateChainEngine(config, &mut engine) };
+
+        #[allow(clippy::as_conversions)]
+        let engine = call_with_last_error(|| match NonNull::new(engine as *mut c_void) {
+            Some(c) if res == TRUE => Some(c),
+            _ => None,
+        })?;
+
+        Ok(Self { inner: engine })
+    }
+}
+
+impl Drop for CertEngine {
+    fn drop(&mut self) {
+        // SAFETY: The engine pointer is guaranteed to be non-null.
+        unsafe { CertFreeCertificateChainEngine(EnginePtr::from_raw(self.inner)) };
+    }
+}
+
+// SAFETY: We know no other threads is mutating the `CertEngine`, because it would require `unsafe`.
+// Across the FFI, `CertGetCertificateChain` don't mutate it either.
+unsafe impl Sync for CertEngine {}
+// SAFETY: All methods of `CertEngine`, including `Drop`, are safe to be called from other
+// threads, because all contained resources are owned by Windows and we only maintain reference counted handles to them.
+unsafe impl Send for CertEngine {}
+
+/// An in-memory Windows certificate store.
+///
+/// # Safety
+///
+/// `CertificateStore` creates `Certificate` objects that may outlive the
+/// `CertificateStore`. This is only safe to do if the certificate store is
+/// constructed with `CERT_STORE_DEFER_CLOSE_UNTIL_LAST_FREE_FLAG`.
+struct CertificateStore {
+    inner: NonNull<c_void>, // HCERTSTORE
+    // In production code, this is always `None`.
+    //
+    // During tests, we set this to `Some` as the tests use a
+    // custom verification engine that only uses specific roots.
+    engine: Option<CertEngine>, // HCERTENGINECONTEXT
+}
+
+impl CertificateStore {
+    #[cfg(any(test, feature = "ffi-testing", feature = "dbg"))]
+    fn new_with_fake_root(root: &[u8]) -> Result<Self, TlsError> {
+        let mut inner = Self::new()?;
+
+        let mut root_store = Self::new()?;
+        root_store.add_cert(root)?;
+
+        let engine = CertEngine::new_with_fake_root(root)?;
+        inner.engine = Some(engine);
+
+        Ok(inner)
+    }
+
+    /// Creates a new, in-memory certificate store.
+    fn new() -> Result<Self, TlsError> {
+        let store = call_with_last_error(|| {
+            // SAFETY: Called with valid constants and result is checked to be non-null.
+            // The `CERT_STORE_DEFER_CLOSE_UNTIL_LAST_FREE_FLAG` flag is critical;
+            // see the `CertificateStore` documentation for more info.
+            NonNull::new(unsafe {
+                CertOpenStore(
+                    CERT_STORE_PROV_MEMORY,
+                    0, // Set to zero since this uses `PROV_MEMORY`.
+                    0, // This field shouldn't be used.
+                    CERT_STORE_DEFER_CLOSE_UNTIL_LAST_FREE_FLAG,
+                    ptr::null(),
+                )
+            })
+        })?;
+
+        // Use the system's default root store and rules.
+        Ok(Self {
+            inner: store,
+            engine: None,
+        })
+    }
+
+    /// Adds the provided certificate to the store.
+    ///
+    /// The certificate must be encoded as ASN.1 DER.
+    ///
+    /// Errors if the certificate was malformed and couldn't be added.
+    fn add_cert(&mut self, cert: &[u8]) -> Result<Certificate, TlsError> {
+        let mut cert_context: *mut CERT_CONTEXT = ptr::null_mut();
+
+        // SAFETY: `inner` is a valid certificate store, and `cert` is a valid a byte array valid
+        // for reads, the correct length is being provided, and `cert_context` is valid to write to.
+        let res = unsafe {
+            CertAddEncodedCertificateToStore(
+                self.inner.as_ptr(),
+                X509_ASN_ENCODING,
+                cert.as_ptr(),
+                cert.len()
+                    .try_into()
+                    .map_err(|_| InvalidCertificate(CertificateError::BadEncoding))?,
+                CERT_STORE_ADD_ALWAYS,
+                &mut cert_context,
+            )
+        };
+
+        // SAFETY: Constructing a `Certificate` is only safe if the store was
+        // created with the right flags; see the `CertificateStore` docs.
+        match (res, NonNull::new(cert_context)) {
+            (TRUE, Some(cert)) => Ok(Certificate { inner: cert }),
+            _ => Err(InvalidCertificate(CertificateError::BadEncoding)),
+        }
+    }
+
+    fn new_chain_in(
+        &self,
+        certificate: &Certificate,
+        now: pki_types::UnixTime,
+        engine: Option<&CertEngine>,
+    ) -> Result<CertChain, TlsError> {
+        let mut cert_chain = ptr::null_mut();
+
+        let mut parameters = CERT_CHAIN_PARA::zeroed_with_size();
+
+        #[allow(clippy::as_conversions)]
+        // https://docs.microsoft.com/en-us/windows/win32/api/wincrypt/ns-wincrypt-cert_usage_match
+        let usage = CERT_USAGE_MATCH {
+            dwType: USAGE_MATCH_TYPE_AND,
+            Usage: CTL_USAGE {
+                cUsageIdentifier: ALLOWED_EKUS.len() as u32,
+                rgpszUsageIdentifier: ALLOWED_EKUS.as_ptr() as *mut windows_sys::core::PSTR,
+            },
+        };
+        parameters.RequestedUsage = usage;
+
+        #[allow(clippy::as_conversions)]
+        let time = {
+            /// Seconds between Jan 1st, 1601 and Jan 1, 1970.
+            const UNIX_ADJUSTMENT: std::time::Duration =
+                std::time::Duration::from_secs(11_644_473_600);
+
+            let since_unix_epoch = now.as_secs();
+
+            // Convert the duration from the UNIX epoch to the Window one, and then convert
+            // the result into a `FILETIME` structure.
+
+            let since_windows_epoch = since_unix_epoch + UNIX_ADJUSTMENT.as_secs();
+            let intervals = (since_windows_epoch * 1_000_000_000) / 100;
+
+            FILETIME {
+                dwLowDateTime: (intervals & u32::MAX as u64) as u32,
+                dwHighDateTime: (intervals >> 32) as u32,
+            }
+        };
+
+        // `CERT_CHAIN_REVOCATION_CHECK_END_CERT` only checks revocation for end cert. See the crate's revocation documentation
+        // for more details.
+        // `CERT_CHAIN_REVOCATION_ACCUMULATIVE_TIMEOUT` accumulates network retrievals timeouts
+        // to limit network time and improve performance.
+        // `CERT_CHAIN_CACHE_END_CERT` speeds up the common case of multiple connections to same server.
+        const FLAGS: u32 = CERT_CHAIN_REVOCATION_CHECK_END_CERT
+            | CERT_CHAIN_REVOCATION_ACCUMULATIVE_TIMEOUT
+            | CERT_CHAIN_CACHE_END_CERT;
+
+        // Lowering URL retrieval timeout from default 15s to 10s to account for higher internet speeds
+        parameters.dwUrlRetrievalTimeout = 3 * 1000; // milliseconds
+
+        // SAFETY: `cert` points to a valid certificate context, parameters is valid for reads, `cert_chain` is valid
+        // for writes, and the certificate store is valid and initialized.
+        let res = unsafe {
+            // XXX: Due to the redefinition of `CERT_CHAIN_PARA`, we need to do pointer casts
+            // in order to pass our expanded structure into `CertGetCertificateChain`.
+            // This is safe because the OS uses `cbSize` to know if the extra parameters
+            // are present or not. As we set `cbSize` correctly, the fields can be read from correctly.
+            let parameters = NonNull::from(&parameters).cast().as_ptr();
+
+            CertGetCertificateChain(
+                match engine {
+                    Some(eng) => EnginePtr::from_raw(eng.inner),
+                    None => EnginePtr::NULL,
+                },
+                certificate.inner.as_ptr(),
+                &time,
+                self.inner.as_ptr(),
+                parameters,
+                FLAGS,
+                ptr::null_mut(),
+                &mut cert_chain,
+            )
+        };
+
+        // XXX: Windows will internally map the chain's `TrustStatus.dwErrorStatus` to a `dwError` when
+        // a chain policy is verified, so we only check for errors there.
+        call_with_last_error(|| match NonNull::new(cert_chain) {
+            Some(c) if res == TRUE => Some(CertChain { inner: c }),
+            _ => None,
+        })
+    }
+}
+
+impl Drop for CertificateStore {
+    fn drop(&mut self) {
+        // SAFETY: See the `CertificateStore` documentation.
+        unsafe { CertCloseStore(self.inner.as_ptr(), 0) };
+    }
+}
+
+struct CertChain {
+    inner: NonNull<CERT_CHAIN_CONTEXT>,
+}
+
+impl CertChain {
+    fn verify_chain_policy(
+        &self,
+        mut server_null_terminated: Vec<u16>,
+    ) -> Result<CERT_CHAIN_POLICY_STATUS, TlsError> {
+        let mut extra_params = HTTPSPolicyCallbackData::zeroed_with_size();
+        extra_params.dwAuthType = AUTHTYPE_SERVER;
+        // `server_null_terminated` outlives `extra_params`.
+        extra_params.pwszServerName = server_null_terminated.as_mut_ptr();
+
+        let mut params = CERT_CHAIN_POLICY_PARA::zeroed_with_size();
+        // Ignore any errors when trying to obtain OCSP revocation information.
+        // This is also done in OpenSSL, Secure Transport from Apple, etc.
+        params.dwFlags = CERT_CHAIN_POLICY_IGNORE_ALL_REV_UNKNOWN_FLAGS;
+        // `extra_params` outlives `params`.
+        params.pvExtraPolicyPara = NonNull::from(&mut extra_params).cast::<c_void>().as_ptr();
+
+        let mut status: MaybeUninit<CERT_CHAIN_POLICY_STATUS> = MaybeUninit::uninit();
+
+        // SAFETY: The certificate chain is non-null, `params` is valid for reads, and its valid to write to `status`.
+        let res = unsafe {
+            CertVerifyCertificateChainPolicy(
+                CERT_CHAIN_POLICY_SSL,
+                self.inner.as_ptr(),
+                &params,
+                status.as_mut_ptr(),
+            )
+        };
+
+        // This should rarely, if ever, be false since it would imply no TLS verification
+        // is currently possible on the system: https://docs.microsoft.com/en-us/windows/win32/api/wincrypt/nf-wincrypt-certverifycertificatechainpolicy#return-value
+        if res != TRUE {
+            return Err(TlsError::General(String::from(
+                "TLS certificate verification was unavailable on the system!",
+            )));
+        }
+
+        // SAFETY: The verification call was checked to have succeeded, so the status
+        // is written correctly and initialized.
+        let status = unsafe { status.assume_init() };
+        Ok(status)
+    }
+}
+
+impl Drop for CertChain {
+    fn drop(&mut self) {
+        // SAFETY: The pointer is guaranteed to be non-null.
+        unsafe { CertFreeCertificateChain(self.inner.as_ptr()) }
+    }
+}
+
+/// A representation of a certificate.
+///
+/// The `CertificateStore` must be opened with the correct flags to ensure the
+/// certificate may outlive it; see the `CertificateStore` documentation.
+struct Certificate {
+    inner: NonNull<CERT_CONTEXT>,
+}
+
+impl Certificate {
+    /// Sets the specified property of this certificate context.
+    ///
+    /// ### Safety
+    /// `prop_data` must be a valid pointer for the property type.
+    unsafe fn set_property(
+        &mut self,
+        prop_id: u32,
+        prop_data: *const c_void,
+    ) -> Result<(), TlsError> {
+        // SAFETY: `cert` points to a valid certificate context and the OCSP data is valid to read.
+        call_with_last_error(|| {
+            (CertSetCertificateContextProperty(
+                self.inner.as_ptr(),
+                prop_id,
+                CERT_SET_PROPERTY_IGNORE_PERSIST_ERROR_FLAG,
+                prop_data,
+            ) == TRUE)
+                .then_some(())
+        })
+    }
+}
+
+impl Drop for Certificate {
+    fn drop(&mut self) {
+        // SAFETY: The certificate context is non-null and points to a valid location.
+        unsafe { CertFreeCertificateContext(self.inner.as_ptr()) };
+    }
+}
+
+// The `windows-sys` definition for `CERT_CHAIN_PARA` does not take old OS versions
+// into account so we define it ourselves for better OS backwards compat.
+// In the future a compile-time size assertion can be added against the upstream type to help stay in sync.
+#[allow(non_camel_case_types, non_snake_case)]
+#[repr(C)]
+struct CERT_CHAIN_PARA {
+    pub cbSize: u32,
+    pub RequestedUsage: CERT_USAGE_MATCH,
+    pub RequestedIssuancePolicy: CERT_USAGE_MATCH,
+    pub dwUrlRetrievalTimeout: u32,
+    pub fCheckRevocationFreshnessTime: i32, // BOOL
+    pub dwRevocationFreshnessTime: u32,
+    pub pftCacheResync: *mut FILETIME,
+    // XXX: `pStrongSignPara` and `dwStrongSignFlags` might or might not be defined on the current system. It started
+    // being available in Windows 8. See https://docs.microsoft.com/en-us/windows/win32/api/wincrypt/ns-wincrypt-cert_chain_para
+    #[cfg(not(target_vendor = "win7"))]
+    pub pStrongSignPara: *const CERT_STRONG_SIGN_PARA,
+    #[cfg(not(target_vendor = "win7"))]
+    pub dwStrongSignFlags: u32,
+}
+
+// SAFETY: see method implementation
+unsafe impl ZeroedWithSize for CERT_CHAIN_PARA {
+    fn zeroed_with_size() -> Self {
+        // SAFETY: `CERT_CHAIN_PARA` only contains pointers and integers, which are safe to zero.
+        // Additionally, MSDN states you *MUST* zero all unused fields.
+        let mut new: Self = unsafe { mem::zeroed() };
+        new.cbSize = Self::SIZE;
+        new
+    }
+}
+
+// Same workaround with CERT_CHAIN_PARA
+#[allow(non_camel_case_types, non_snake_case)]
+#[repr(C)]
+#[derive(Clone, Copy)]
+pub struct CERT_CHAIN_ENGINE_CONFIG {
+    pub cbSize: u32,
+    pub hRestrictedRoot: HCERTSTORE,
+    pub hRestrictedTrust: HCERTSTORE,
+    pub hRestrictedOther: HCERTSTORE,
+    pub cAdditionalStore: u32,
+    pub rghAdditionalStore: *mut HCERTSTORE,
+    pub dwFlags: u32,
+    pub dwUrlRetrievalTimeout: u32,
+    pub MaximumCachedCertificates: u32,
+    pub CycleDetectionModulus: u32,
+    pub hExclusiveRoot: HCERTSTORE,
+    pub hExclusiveTrustedPeople: HCERTSTORE,
+    // XXX: `dwExclusiveFlags` started being available in Windows 8 and Windows Server 2012
+    // See https://learn.microsoft.com/en-us/windows/win32/api/wincrypt/ns-wincrypt-cert_chain_engine_config
+    #[cfg(not(target_vendor = "win7"))]
+    pub dwExclusiveFlags: u32,
+}
+
+// `windows-sys` >= 0.60
+impl EnginePtr for *mut c_void {
+    fn from_raw(val: NonNull<c_void>) -> Self {
+        val.as_ptr()
+    }
+
+    const NULL: Self = ptr::null_mut();
+}
+
+// `windows-sys` 0.52-0.59
+impl EnginePtr for isize {
+    #[allow(clippy::as_conversions)]
+    fn from_raw(val: NonNull<c_void>) -> Self {
+        val.as_ptr() as isize
+    }
+
+    const NULL: Self = 0;
+}
+
+/// An abstraction trait over the different ways various `windows-sys` versions represent
+/// the type of `HCERTCHAINENGINE`.
+trait EnginePtr: Sized {
+    fn from_raw(val: NonNull<c_void>) -> Self;
+
+    const NULL: Self;
+}
+
+// SAFETY: see method implementation
+unsafe impl ZeroedWithSize for HTTPSPolicyCallbackData {
+    fn zeroed_with_size() -> Self {
+        // SAFETY: zeroed is needed here since it contains a union.
+        let mut new: Self = unsafe { mem::zeroed() };
+        new.Anonymous.cbSize = Self::SIZE;
+        new
+    }
+}
+
+// SAFETY: see method implementation
+unsafe impl ZeroedWithSize for CERT_CHAIN_POLICY_PARA {
+    fn zeroed_with_size() -> Self {
+        // SAFETY: This structure only contains integers and pointers.
+        let mut new: Self = unsafe { mem::zeroed() };
+        new.cbSize = Self::SIZE;
+        new
+    }
+}
+
+// SAFETY: see method implementation
+unsafe impl ZeroedWithSize for CERT_CHAIN_ENGINE_CONFIG {
+    fn zeroed_with_size() -> Self {
+        // SAFETY: This structure only contains integers and pointers.
+        let mut new: Self = unsafe { mem::zeroed() };
+        new.cbSize = Self::SIZE;
+        new
+    }
+}
+
 /// A trait to represent an object that can be safely created with all zero values
 /// and have a size assigned to it.
 ///
@@ -789,4 +777,14 @@ unsafe trait ZeroedWithSize: Sized {
 
     /// Returns a zeroed structure with its structure size (`cbSize`) field set to the correct value.
     fn zeroed_with_size() -> Self;
+}
+
+fn call_with_last_error<T, F: FnMut() -> Option<T>>(mut call: F) -> Result<T, TlsError> {
+    if let Some(res) = call() {
+        Ok(res)
+    } else {
+        Err(TlsError::General(
+            std::io::Error::last_os_error().to_string(),
+        ))
+    }
 }

--- a/rustls-platform-verifier/src/verification/windows.rs
+++ b/rustls-platform-verifier/src/verification/windows.rs
@@ -33,6 +33,10 @@ use rustls::{
     CertificateError, DigitallySignedStruct, Error as TlsError, Error::InvalidCertificate,
     SignatureScheme,
 };
+#[cfg(any(test, feature = "ffi-testing", feature = "dbg"))]
+use windows_sys::Win32::Security::Cryptography::{
+    CERT_CHAIN_CACHE_ONLY_URL_RETRIEVAL, CERT_CHAIN_ENABLE_CACHE_AUTO_UPDATE,
+};
 use windows_sys::Win32::{
     Foundation::{
         CERT_E_CN_NO_MATCH, CERT_E_EXPIRED, CERT_E_INVALID_NAME, CERT_E_UNTRUSTEDROOT,
@@ -273,10 +277,6 @@ impl CertEngine {
 
     #[cfg(any(test, feature = "ffi-testing", feature = "dbg"))]
     fn new_with_fake_root(root: &[u8]) -> Result<Self, TlsError> {
-        use windows_sys::Win32::Security::Cryptography::{
-            CERT_CHAIN_CACHE_ONLY_URL_RETRIEVAL, CERT_CHAIN_ENABLE_CACHE_AUTO_UPDATE,
-        };
-
         let mut root_store = CertificateStore::new()?;
         root_store.add_cert(root)?;
 

--- a/rustls-platform-verifier/src/verification/windows.rs
+++ b/rustls-platform-verifier/src/verification/windows.rs
@@ -385,9 +385,7 @@ impl CertificateStore {
     #[cfg(any(test, feature = "ffi-testing", feature = "dbg"))]
     fn new_with_fake_root(root: pki_types::CertificateDer<'static>) -> Result<Self, TlsError> {
         let mut inner = Self::new()?;
-
-        let mut root_store = Self::new()?;
-        root_store.add_cert(&root)?;
+        inner.add_cert(&root)?;
 
         let engine = CertEngine::new_with_fake_root(root)?;
         inner.engine = Some(engine);

--- a/rustls-platform-verifier/src/verification/windows.rs
+++ b/rustls-platform-verifier/src/verification/windows.rs
@@ -129,7 +129,7 @@ impl Verifier {
         #[cfg(any(test, feature = "ffi-testing", feature = "dbg"))]
         let mut store = match self.test_only_root_ca_override.as_ref() {
             Some(test_only_root_ca_override) => {
-                CertificateStore::new_with_fake_root(test_only_root_ca_override)?
+                CertificateStore::new_with_fake_root(test_only_root_ca_override.clone())?
             }
             None => CertificateStore::new()?,
         };
@@ -326,9 +326,9 @@ impl CertEngine {
     }
 
     #[cfg(any(test, feature = "ffi-testing", feature = "dbg"))]
-    fn new_with_fake_root(root: &[u8]) -> Result<Self, TlsError> {
+    fn new_with_fake_root(root: pki_types::CertificateDer<'static>) -> Result<Self, TlsError> {
         let mut root_store = CertificateStore::new()?;
-        root_store.add_cert(root)?;
+        root_store.add_cert(&root)?;
 
         let mut config = CERT_CHAIN_ENGINE_CONFIG::zeroed_with_size();
         // We use these flags for the following reasons:
@@ -391,11 +391,11 @@ struct CertificateStore {
 
 impl CertificateStore {
     #[cfg(any(test, feature = "ffi-testing", feature = "dbg"))]
-    fn new_with_fake_root(root: &[u8]) -> Result<Self, TlsError> {
+    fn new_with_fake_root(root: pki_types::CertificateDer<'static>) -> Result<Self, TlsError> {
         let mut inner = Self::new()?;
 
         let mut root_store = Self::new()?;
-        root_store.add_cert(root)?;
+        root_store.add_cert(&root)?;
 
         let engine = CertEngine::new_with_fake_root(root)?;
         inner.engine = Some(engine);

--- a/rustls-platform-verifier/src/verification/windows.rs
+++ b/rustls-platform-verifier/src/verification/windows.rs
@@ -466,7 +466,7 @@ impl CertificateStore {
             | CERT_CHAIN_CACHE_END_CERT;
 
         // Lowering URL retrieval timeout from default 15s to 10s to account for higher internet speeds
-        parameters.dwUrlRetrievalTimeout = 10 * 1000; // milliseconds
+        parameters.dwUrlRetrievalTimeout = 3 * 1000; // milliseconds
 
         // SAFETY: `cert` points to a valid certificate context, parameters is valid for reads, `cert_chain` is valid
         // for writes, and the certificate store is valid and initialized.

--- a/rustls-platform-verifier/src/verification/windows.rs
+++ b/rustls-platform-verifier/src/verification/windows.rs
@@ -34,9 +34,7 @@ use rustls::{
     SignatureScheme,
 };
 #[cfg(any(test, feature = "ffi-testing", feature = "dbg"))]
-use windows_sys::Win32::Security::Cryptography::{
-    CERT_CHAIN_CACHE_ONLY_URL_RETRIEVAL, CERT_CHAIN_ENABLE_CACHE_AUTO_UPDATE,
-};
+use windows_sys::Win32::Security::Cryptography::CERT_CHAIN_ENABLE_CACHE_AUTO_UPDATE;
 use windows_sys::Win32::{
     Foundation::{
         CERT_E_CN_NO_MATCH, CERT_E_EXPIRED, CERT_E_INVALID_NAME, CERT_E_UNTRUSTEDROOT,
@@ -47,7 +45,7 @@ use windows_sys::Win32::{
         CertFreeCertificateChain, CertFreeCertificateChainEngine, CertFreeCertificateContext,
         CertGetCertificateChain, CertOpenStore, CertSetCertificateContextProperty,
         CertVerifyCertificateChainPolicy, HTTPSPolicyCallbackData, AUTHTYPE_SERVER,
-        CERT_CHAIN_CACHE_END_CERT, CERT_CHAIN_CONTEXT,
+        CERT_CHAIN_CACHE_END_CERT, CERT_CHAIN_CACHE_ONLY_URL_RETRIEVAL, CERT_CHAIN_CONTEXT,
         CERT_CHAIN_POLICY_IGNORE_ALL_REV_UNKNOWN_FLAGS, CERT_CHAIN_POLICY_PARA,
         CERT_CHAIN_POLICY_SSL, CERT_CHAIN_POLICY_STATUS,
         CERT_CHAIN_REVOCATION_ACCUMULATIVE_TIMEOUT, CERT_CHAIN_REVOCATION_CHECK_END_CERT,
@@ -99,6 +97,20 @@ impl Verifier {
             test_only_root_ca_override: None,
             crypto_provider,
             extra_roots: Some(cert_engine),
+        })
+    }
+
+    /// Creates a Windows TLS certificate verifier that avoids using online revocation checking.
+    #[cfg_attr(docsrs, doc(cfg(all())))]
+    pub fn offline(
+        roots: impl IntoIterator<Item = pki_types::CertificateDer<'static>>,
+        crypto_provider: Arc<CryptoProvider>,
+    ) -> Result<Self, TlsError> {
+        Ok(Self {
+            #[cfg(any(test, feature = "ffi-testing", feature = "dbg"))]
+            test_only_root_ca_override: None,
+            crypto_provider,
+            extra_roots: Some(CertEngine::new(roots, CERT_CHAIN_CACHE_ONLY_URL_RETRIEVAL)?),
         })
     }
 


### PR DESCRIPTION
Does a bunch of cleanup/refactoring first, and tightens the timeout from 10 to 3s.

Fixes #237.