### PR TITLE
Fix Windows compatibility with hostnames containing a trailing label

### DIFF
--- a/rustls-platform-verifier/src/tests/verification_mock/mod.rs
+++ b/rustls-platform-verifier/src/tests/verification_mock/mod.rs
@@ -152,6 +152,16 @@ mock_root_test_cases! {
         expected_result: Ok(()),
         other_error: no_error!(),
     },
+    valid_no_stapling_dns_trailing_label [ any(windows, unix) ] => TestCase {
+        // XXX: `pki_types` validates that the label is still valid and that cases such as two `.` characters
+        // are still correctly rejected.
+        reference_id: "example.com.",
+        chain: &[ROOT1_INT1_EXAMPLE_COM_GOOD, ROOT1_INT1],
+        stapled_ocsp: None,
+        verification_time: verification_time(),
+        expected_result: Ok(()),
+        other_error: no_error!(),
+    },
     valid_no_stapling_ipv4 [ any(windows, unix) ] => TestCase {
         reference_id: LOCALHOST_IPV4,
         chain: &[ROOT1_INT1_LOCALHOST_IPV4_GOOD, ROOT1_INT1],

--- a/rustls-platform-verifier/src/verification/android.rs
+++ b/rustls-platform-verifier/src/verification/android.rs
@@ -91,7 +91,7 @@ impl Verifier {
         &self,
         end_entity: &pki_types::CertificateDer<'_>,
         intermediates: &[pki_types::CertificateDer<'_>],
-        server_name: &pki_types::ServerName<'_>,
+        server_name: &pki_types::ServerName,
         ocsp_response: Option<&[u8]>,
         now: pki_types::UnixTime,
     ) -> Result<(), TlsError> {
@@ -172,7 +172,11 @@ impl Verifier {
                 ) -> org.rustls.platformverifier.VerificationResult
             );
 
-            let server_name = cx.env.new_string(server_name.to_str())?;
+            let server_name = server_name.to_str();
+            // Android's verifier doesn't require this but trim trailing `.` labels for consistency across platforms.
+            let server_name = server_name.strip_suffix('.').unwrap_or(&server_name);
+
+            let server_name = cx.env.new_string(server_name)?;
             let auth_type = cx.env.new_string(AUTH_TYPE)?;
 
             let result = cx

--- a/rustls-platform-verifier/src/verification/apple.rs
+++ b/rustls-platform-verifier/src/verification/apple.rs
@@ -257,6 +257,8 @@ impl ServerCertVerifier for Verifier {
         // Convert IP addresses to name strings to ensure match check on leaf certificate.
         // Ref: https://developer.apple.com/documentation/security/1392592-secpolicycreatessl
         let server = server_name.to_str();
+        // Apple's verifier doesn't require this but trim trailing `.` labels for consistency across platforms.
+        let server = server.strip_suffix('.').unwrap_or(&server);
 
         let ocsp_data = if !ocsp_response.is_empty() {
             Some(ocsp_response)
@@ -264,7 +266,7 @@ impl ServerCertVerifier for Verifier {
             None
         };
 
-        match self.verify_certificate(end_entity, intermediates, &server, ocsp_data, now) {
+        match self.verify_certificate(end_entity, intermediates, server, ocsp_data, now) {
             Ok(()) => Ok(rustls::client::danger::ServerCertVerified::assertion()),
             Err(e) => {
                 // This error only tells us what the system errored with, so it doesn't leak anything

--- a/rustls-platform-verifier/src/verification/windows.rs
+++ b/rustls-platform-verifier/src/verification/windows.rs
@@ -707,6 +707,12 @@ impl ServerCertVerifier for Verifier {
         log_server_cert(end_entity);
 
         let name = server_name.to_str();
+        // Trim trailing `.` labels to remove compatibility hazards with the Windows verifier.
+        // It performs exact quality comparisions in most cases (see https://learn.microsoft.com/en-us/windows/win32/api/wincrypt/ns-wincrypt-httpspolicycallbackdata)
+        // which causes problems with hostnames that are considered equivalent for security purposes in other verifier and TLS implementations.
+        //
+        // Ref: https://github.com/rustls/rustls-platform-verifier/issues/240
+        let name = name.strip_suffix('.').unwrap_or(&name);
 
         let intermediate_certs: Vec<&[u8]> = intermediates.iter().map(|c| c.as_ref()).collect();
 


### PR DESCRIPTION
This PR fixes a small incompatibility in the Windows verifier around hostnames which have a trailing `.` in them that originates from the Win32 API itself.

Other platforms do not appear to have the same limitation but I added the same stripping change everywhere to help keep the Rust layer of this library consistent cross-platform per its goals.

Closes #240 